### PR TITLE
chore: migrate from node 12 to node 10

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
     - name: Checkout Git repo
       uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.19.0
+        registry-url: https://registry.npmjs.com/
     
     - name: Cache node_modules
       uses: actions/cache@v2

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "4.0.0",
+  "lerna": "3.15.0",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/packages/change-analysis-models/change-analysis-report/change-analysis-report.ts
+++ b/packages/change-analysis-models/change-analysis-report/change-analysis-report.ts
@@ -5,6 +5,7 @@ import { Aggregation, aggregationSerializer } from "../aggregations";
 import { ComponentOperation, InfraModelDiff, Transition, UpdatePropertyComponentOperation } from "../model-diffing";
 import { Component } from "../infra-model";
 import { RuleEffect } from "../rules";
+import { fromEntries } from "../utils";
 
 export class ChangeAnalysisReport implements JSONSerializable {
 
@@ -22,12 +23,12 @@ export class ChangeAnalysisReport implements JSONSerializable {
         return {
             infraModelDiff: serialize(this.infraModelDiff),
             aggregations: this.aggregations.map(agg => this.serializeAgg(agg, serialize, serializeCustom)),
-            aggregationsPerComponent: Object.fromEntries(
+            aggregationsPerComponent: fromEntries(
                 [...this.aggregationsPerComponent].map(([compTransition, aggArr]) => {
                     return [serialize(compTransition), aggArr.map(agg => this.serializeAgg(agg, serialize, serializeCustom))];
                 })
             ),
-            rulesOutput: Object.fromEntries(
+            rulesOutput: fromEntries(
                 [...this.rulesOutput].map(([op, effect]) => [serialize(op), effect])
             )
         };

--- a/packages/change-analysis-models/export/deserializers/infra-model/component-property-deserializer.ts
+++ b/packages/change-analysis-models/export/deserializers/infra-model/component-property-deserializer.ts
@@ -1,4 +1,5 @@
 import { ComponentPropertyValue, ComponentPropertyArray, ComponentPropertyPrimitive, ComponentPropertyRecord, EmptyComponentProperty } from "../../../infra-model";
+import { fromEntries } from "../../../utils";
 import { JSONSerializable, Serialized } from "../../json-serializable";
 import { SerializationID } from "../../json-serializer";
 import { SerializedComponentPropertyArray, SerializedComponentPropertyPrimitive, SerializedComponentPropertyRecord } from "../../serialized-interfaces/infra-model/serialized-component-property";
@@ -16,7 +17,7 @@ export function componentPropertyRecordDeserializer(obj: Serialized, deserialize
     const serializedComponentProperty = obj as SerializedComponentPropertyRecord;
 
     return new ComponentPropertyRecord(
-        Object.fromEntries(Object.entries(serializedComponentProperty.value).map(([k,v]) => [k, deserialize(v) as ComponentPropertyValue])),
+        fromEntries(Object.entries(serializedComponentProperty.value).map(([k,v]) => [k, deserialize(v) as ComponentPropertyValue])),
         serializedComponentProperty.componentUpdateType
     );
 }

--- a/packages/change-analysis-models/infra-model/component-property.ts
+++ b/packages/change-analysis-models/infra-model/component-property.ts
@@ -2,6 +2,7 @@ import { JSONSerializable } from "../export/json-serializable";
 import { SerializationID } from "../export/json-serializer";
 import { SerializationClasses } from "../export/serialization-classes";
 import { SerializedComponentProperty, SerializedComponentPropertyArray, SerializedComponentPropertyEmpty, SerializedComponentPropertyPrimitive, SerializedComponentPropertyRecord } from "../export/serialized-interfaces/infra-model/serialized-component-property";
+import { flatMap, fromEntries } from "../utils";
 import { ModelEntity, OutgoingReferences } from "./model-entity";
 import { ModelEntityTypes } from "./model-entity-types";
 
@@ -100,7 +101,7 @@ export abstract class ComponentPropertyValue/* TODO Value*/<ND extends NodeData 
     public explode(): ComponentPropertyValue[]{
         if(this.isPrimitive() || this.value === undefined) return [this];
         
-        return Object.values(this.value).flatMap(v => v.explode());
+        return flatMap(Object.values(this.value), v => v.explode());
     }
 
     public abstract toSerialized(serialize: (obj: JSONSerializable) => SerializationID): SerializedComponentProperty;
@@ -133,7 +134,7 @@ export class ComponentPropertyRecord extends ComponentCollectionProperty  {
 
     public toSerialized(serialize: (obj: JSONSerializable) => SerializationID): SerializedComponentPropertyRecord {
         return {
-            value: Object.fromEntries(Object.entries(this.getRecord()).map(([k, v]) => [k, serialize(v)])),
+            value: fromEntries(Object.entries(this.getRecord()).map(([k, v]) => [k, serialize(v)])),
             componentUpdateType: this.componentUpdateType,
         };
     }

--- a/packages/change-analysis-models/infra-model/model-entity.ts
+++ b/packages/change-analysis-models/infra-model/model-entity.ts
@@ -1,6 +1,6 @@
 import * as fn from 'fifinet';
 import { Serialized } from '../export/json-serializable';
-import { isDefined } from '../utils';
+import { flatMap, isDefined } from '../utils';
 
 export type OutgoingReferences = Record<
     string,
@@ -38,7 +38,7 @@ export class ModelEntity<
             refName: label, ref: e, key
         });
         
-        return Object.entries(this.outgoingNodeReferences).flatMap(([k, v]) => {
+        return flatMap(Object.entries(this.outgoingNodeReferences), ([k, v]) => {
             if(v instanceof ModelEntity){
                 return [createInfoObj(k, v)];
             } if(v instanceof Set) {
@@ -65,6 +65,6 @@ export class ModelEntity<
 
     public generateOutgoingGraph() { 
         const entities = this.explodeNodeReferences();
-        return new fn.Graph(entities.map(e => e.nodeData), entities.flatMap(e => e.getOutgoingNodeEdges()));
+        return new fn.Graph(entities.map(e => e.nodeData), flatMap(entities, e => e.getOutgoingNodeEdges()));
     }
 }

--- a/packages/change-analysis-models/model-diffing/infra-model-diff.ts
+++ b/packages/change-analysis-models/model-diffing/infra-model-diff.ts
@@ -2,7 +2,7 @@ import { JSONSerializable, Serialized } from "../export/json-serializable";
 import { SerializationID } from "../export/json-serializer";
 import { SerializationClasses } from "../export/serialization-classes";
 import { Component, InfraModel, ModelEntity } from "../infra-model";
-import { groupArrayBy, isDefined } from "../utils";
+import { flatMap, groupArrayBy, isDefined } from "../utils";
 import { ComponentOperation } from "./operations";
 import { Transition } from "./transition";
 
@@ -37,7 +37,7 @@ export class InfraModelDiff extends ModelEntity<{}, OutgoingNodeReferences> impl
         componentTransitions: Transition<Component>[]
     ): Map<Component, Transition<Component>> {
         return new Map(
-            componentTransitions.flatMap(t => [[t.v1, t], [t.v2, t]])
+            flatMap(componentTransitions, t => [[t.v1, t], [t.v2, t]])
             .filter(([v]) => isDefined(v)) as [Component, Transition<Component>][]
         );
     }

--- a/packages/change-analysis-models/model-diffing/operations/property-component-operation.ts
+++ b/packages/change-analysis-models/model-diffing/operations/property-component-operation.ts
@@ -2,7 +2,7 @@ import { JSONSerializable } from "../../export/json-serializable";
 import { SerializationClasses } from "../../export/serialization-classes";
 import { SerializedPropertyComponentOperation, SerializedUpdatePropertyComponentOperation } from "../../export/serialized-interfaces/infra-model-diff/serialized-component-operation";
 import { ComponentPropertyValue, ComponentUpdateType, PropertyPath } from "../../infra-model";
-import { arraysEqual } from "../../utils";
+import { arraysEqual, flatMap } from "../../utils";
 import { Transition } from "../transition";
 import { ComponentOperation, OperationType, OpNodeData, OpOutgoingNodeReferences } from "./component-operation";
 
@@ -124,7 +124,7 @@ export class UpdatePropertyComponentOperation extends PropertyComponentOperation
         if(!this.innerOperations || this.innerOperations.length === 0) {
             return [this];
         }
-        return this.innerOperations.flatMap(o =>
+        return flatMap(this.innerOperations, o =>
             [this, ...(
                 o instanceof UpdatePropertyComponentOperation
                     ? o.getAllInnerOperations()
@@ -149,7 +149,7 @@ export class UpdatePropertyComponentOperation extends PropertyComponentOperation
 
     public getLeaves(): PropertyComponentOperation[] {
         if(!this.innerOperations) return [this];
-        return this.innerOperations.flatMap(o => (o instanceof UpdatePropertyComponentOperation) ? o.getLeaves() : [o]);
+        return flatMap(this.innerOperations, o => (o instanceof UpdatePropertyComponentOperation) ? o.getLeaves() : [o]);
     }
 
     public toSerialized(

--- a/packages/change-analysis-models/package.json
+++ b/packages/change-analysis-models/package.json
@@ -8,7 +8,7 @@
     "compile": "npx tsc --build",
     "clean": "npx rimraf out",
     "lint": "eslint . --ext .ts",
-    "test": "jest"
+    "test": "npx jest"
   },
   "repository": {
     "type": "git",

--- a/packages/change-analysis-models/package.json
+++ b/packages/change-analysis-models/package.json
@@ -20,6 +20,9 @@
     "url": "https://aws.amazon.com",
     "organization": true
   },
+  "engines": {
+    "node": ">= 10.13.0 <13 || >=13.7.0"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-cdk/cfnspec": "^1.90.0",

--- a/packages/change-analysis-models/utils/index.ts
+++ b/packages/change-analysis-models/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './arrayUtils';
+export * from './node';
 export * from './setUtils';
 export * from './typeGuards';
 export * from './stringUtils';

--- a/packages/change-analysis-models/utils/node.ts
+++ b/packages/change-analysis-models/utils/node.ts
@@ -1,0 +1,24 @@
+/**
+ * Map a function over an array and concatenate the results
+ */
+ export function flatMap<T, U>(xs: T[], fn: ((x: T, i: number) => U[])): U[] {
+  return flatten(xs.map(fn));
+}
+
+/**
+ * Flatten a list of lists into a list of elements
+ */
+export function flatten<T>(xs: T[][]): T[] {
+  return Array.prototype.concat.apply([], xs);
+}
+
+/**
+ * Creates an object representing the given iterable
+ * list of [key, value] pairs.
+ */
+export function fromEntries<T>(iterable: [string | number, T][]): {[key: string]: T}  {
+  return [...iterable].reduce((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {} as {[key: string]: T});
+}

--- a/packages/change-analysis-models/utils/node.ts
+++ b/packages/change-analysis-models/utils/node.ts
@@ -1,24 +1,19 @@
 /**
  * Map a function over an array and concatenate the results
  */
- export function flatMap<T, U>(xs: T[], fn: ((x: T, i: number) => U[])): U[] {
-  return flatten(xs.map(fn));
-}
-
-/**
- * Flatten a list of lists into a list of elements
- */
-export function flatten<T>(xs: T[][]): T[] {
-  return Array.prototype.concat.apply([], xs);
+ export function flatMap<T, U>(xs: T[], f: (x: T) => U[]): U[] {
+  const ret = new Array<U>();
+  for (const x of xs) {
+    ret.push(...f(x));
+  }
+  return ret;
 }
 
 /**
  * Creates an object representing the given iterable
  * list of [key, value] pairs.
  */
-export function fromEntries<T>(iterable: [string | number, T][]): {[key: string]: T}  {
-  return [...iterable].reduce((obj, [key, val]) => {
-    obj[key] = val
-    return obj
-  }, {} as {[key: string]: T});
+export function fromEntries<T>(xs: [string|number|symbol, T][]): {[key: string]: T} {
+  return xs.reduce((acc, [key, value]) => ({ ...acc, [key]: value,}), {});
 }
+ 

--- a/packages/change-analysis/bin/aws-c2a.ts
+++ b/packages/change-analysis/bin/aws-c2a.ts
@@ -27,11 +27,11 @@ async function parseArguments() {
     .usage('Usage: aws-c2a -a <cdk-app> COMMAND')
     .option('app', { type: 'string', alias: 'a', desc: 'REQUIRED: Path to your cloud assembly directory (e.g. "assembly-Pipeline-Stage/")', requiresArg: true, demandOption: true })
     .command('diff [STACKS..]', 'Compares the cdk app the deployed stack or a local template file', yargs => yargs
-      .option('rules-path', { type: 'string', alias: 'r', desc: 'The rules that you want to diff against', requiresArg: true, demandOption: true })
       .option('out', { type: 'string', alias: 'o', desc: 'The output file after running the diff', requiresArg: true, default: 'report.json' })
+      .option('rules-path', { type: 'string', alias: 'r', desc: 'The rules that you want to diff against', requiresArg: true })
       .option('fail', { type: 'boolean', desc: 'Fail with exit code 1 if changes detected', default: false })
       .option('broadening-permissions', { type: 'boolean', desc: 'Add base rules to detect broadening permssions', default: false })
-      .option('fail-condition', { choices: failConditions, desc: 'Add base rules to detect broadening permssions', default: undefined }),
+      .option('fail-condition', { choices: failConditions, desc: 'Configure the risk outputs that cause failure', default: FAIL_ON.HIGH }),
     )
     .version(versionNumber())
     .alias('v', 'version')

--- a/packages/change-analysis/lib/aggregations/add-aggregation-descriptions.ts
+++ b/packages/change-analysis/lib/aggregations/add-aggregation-descriptions.ts
@@ -1,4 +1,5 @@
 import { AggCharacteristicValue, Aggregation } from 'cdk-change-analyzer-models';
+import { flatMap } from '../private/node';
 
 export type AggDescriptionCreator =
     (characteristics: Record<string, AggCharacteristicValue>) => {
@@ -18,7 +19,7 @@ export function addAggDescriptions<T>(
     if(!agg.descriptions)
       agg.descriptions = [];
     const undescribedCharacteristics = new Set(Object.keys(agg.characteristics));
-    agg.descriptions.push(...descriptionCreators.flatMap(creator => {
+    agg.descriptions.push(...flatMap(descriptionCreators, creator => {
       const { descriptions, describedCharacteristics } = creator(agg.characteristics);
       describedCharacteristics?.forEach(c => undescribedCharacteristics.delete(c));
       return descriptions ?? [];

--- a/packages/change-analysis/lib/aggregations/aggregations-extractor.ts
+++ b/packages/change-analysis/lib/aggregations/aggregations-extractor.ts
@@ -1,4 +1,5 @@
 import { AggCharacteristicValue, Aggregation, setsEqual } from 'cdk-change-analyzer-models';
+import { flatMap } from '../private/node';
 import { AggModuleTreeNode } from './aggregation-module-tree-node';
 
 export class ModuleTreeAggsExtractor {
@@ -27,11 +28,11 @@ export class ModuleTreeAggsExtractor {
     if(moduleNode.disableOnNoExtraInfo && directAggs.length <= 1)
       return [];
 
-    const finalAggs = directAggs.flatMap(g => {
+    const finalAggs = flatMap(directAggs, g => {
       const gs = ModuleTreeAggsExtractor.findAggsIntersections<T>(
-        moduleNode.submodules?.flatMap(
+        moduleNode.submodules ? flatMap(moduleNode.submodules,
           sm => ModuleTreeAggsExtractor.extractTreeRoot(sm, g.entities, {...characteristics, ...g.characteristics}),
-        ) ?? [],
+        ) : [],
       );
 
       if(moduleNode.forceSubmoduleCollapse ||

--- a/packages/change-analysis/lib/aggregations/component-operation/extract-operations-aggs.ts
+++ b/packages/change-analysis/lib/aggregations/component-operation/extract-operations-aggs.ts
@@ -8,6 +8,7 @@ import {
   Component,
   RuleEffect,
 } from 'cdk-change-analyzer-models';
+import { flatMap } from '../../private/node';
 import { addAggDescriptions } from '../add-aggregation-descriptions';
 import { ModuleTreeAggsExtractor } from '../aggregations-extractor';
 import * as descriptionCreators from './description-creators';
@@ -44,5 +45,5 @@ export function extractComponentOperationsAggsPerComponent(
 }
 
 const explodeOperations = (ops: ComponentOperation[]) => {
-  return ops.flatMap(o => (o instanceof UpdatePropertyComponentOperation) ? o.getLeaves() : [o]);
+  return flatMap(ops, o => (o instanceof UpdatePropertyComponentOperation) ? o.getLeaves() : [o]);
 };

--- a/packages/change-analysis/lib/model-diffing/diff-creator.ts
+++ b/packages/change-analysis/lib/model-diffing/diff-creator.ts
@@ -13,6 +13,7 @@ import {
   groupArrayBy,
 } from 'cdk-change-analyzer-models';
 import { isDefined } from 'fifinet';
+import { flatMap } from '../private/node';
 import {
   componentSimilarityEvaluator,
   sameNameComponentSimilarityEvaluator,
@@ -48,7 +49,7 @@ export class DiffCreator {
 
     const categories = [...new Set([...oldComponentsGrouped.keys(), ...newComponentsGrouped.keys()])];
 
-    componentOperations.push(...categories.flatMap((type) =>
+    componentOperations.push(...flatMap(categories, (type) =>
       this.diffComponents(
         oldComponentsGrouped.get(type) ?? [],
         newComponentsGrouped.get(type) ?? [],

--- a/packages/change-analysis/lib/model-diffing/entity-matchers/entities-matcher.ts
+++ b/packages/change-analysis/lib/model-diffing/entity-matchers/entities-matcher.ts
@@ -1,4 +1,5 @@
 import { isDefined, CompleteTransition, Transition, JSONSerializable, Serialized } from 'cdk-change-analyzer-models';
+import { flatMap } from '../../private/node';
 
 type ValidEntity = JSONSerializable | Serialized;
 
@@ -73,7 +74,7 @@ function findMatchesDecreasingSimilarity<T extends ValidEntity, K>(
     throw Error('Similarity threshold must be a value between 0 and 1');
 
   const matches: [number, EntityMatch<T,K>][] =
-        entitiesA.flatMap(entityA =>
+        flatMap(entitiesA, entityA =>
           entitiesB.map((entityB): [number, EntityMatch<T,K>] | undefined => {
 
             const transition = new CompleteTransition({v1: entityA, v2: entityB});

--- a/packages/change-analysis/lib/model-diffing/entity-matchers/entities-matcher.ts
+++ b/packages/change-analysis/lib/model-diffing/entity-matchers/entities-matcher.ts
@@ -1,7 +1,6 @@
 import { CompleteTransition, Transition, JSONSerializable, Serialized } from 'cdk-change-analyzer-models';
-import { flatMap } from '../../private/node';
 import {isDefined} from 'fifinet';
-import * as fs from 'fs';
+import { flatMap } from '../../private/node';
 
 type ValidEntity = JSONSerializable | Serialized;
 
@@ -98,6 +97,6 @@ function findMatchesDecreasingSimilarity<T extends ValidEntity, K>(
     .sort((m1, m2) => {
       if (m1[0] > m2[0]) return -1;
       return (m1[0] === m2[0] && +m1[1].transition.nodeData._id < +m2[1].transition.nodeData._id) ? -1 : 1;
-    }) 
+    })
     .map(([, entityMatch]) => entityMatch);
 }

--- a/packages/change-analysis/lib/model-diffing/entity-matchers/entities-matcher.ts
+++ b/packages/change-analysis/lib/model-diffing/entity-matchers/entities-matcher.ts
@@ -1,5 +1,7 @@
-import { isDefined, CompleteTransition, Transition, JSONSerializable, Serialized } from 'cdk-change-analyzer-models';
+import { CompleteTransition, Transition, JSONSerializable, Serialized } from 'cdk-change-analyzer-models';
 import { flatMap } from '../../private/node';
+import {isDefined} from 'fifinet';
+import * as fs from 'fs';
 
 type ValidEntity = JSONSerializable | Serialized;
 
@@ -72,28 +74,30 @@ function findMatchesDecreasingSimilarity<T extends ValidEntity, K>(
 
   if(similarityThreshold < 0 || similarityThreshold > 1)
     throw Error('Similarity threshold must be a value between 0 and 1');
-
   const matches: [number, EntityMatch<T,K>][] =
-        flatMap(entitiesA, entityA =>
-          entitiesB.map((entityB): [number, EntityMatch<T,K>] | undefined => {
+    flatMap(entitiesA, entityA =>
+      entitiesB.map((entityB): [number, EntityMatch<T,K>] | undefined => {
+        const transition = new CompleteTransition({v1: entityA, v2: entityB});
+        const similarityCalcResult = similarityEvaluator(transition);
 
-            const transition = new CompleteTransition({v1: entityA, v2: entityB});
+        if(!similarityCalcResult)
+          return;
 
-            const similarityCalcResult = similarityEvaluator(transition);
+        const [similarity, metadata] = similarityCalcResult;
+        if(similarity < 0 || similarity > 1)
+          throw Error('Similarity does not have a value in the range [0, 1]');
 
-            if(!similarityCalcResult)
-              return;
+        if(similarity > similarityThreshold)
+          return [similarity, {transition, metadata}];
 
-            const [similarity, metadata] = similarityCalcResult;
-            if(similarity < 0 || similarity > 1)
-              throw Error('Similarity does not have a value in the range [0, 1]');
+        return;
+      }),
+    ).filter(isDefined);
 
-            if(similarity > similarityThreshold)
-              return [similarity, {transition, metadata}];
-
-            return;
-          }),
-        ).filter(isDefined);
-
-  return matches.sort((m1, m2) => m1[0] > m2[0] ? -1 : 1).map(([, entityMatch]) => entityMatch);
+  return matches
+    .sort((m1, m2) => {
+      if (m1[0] > m2[0]) return -1;
+      return (m1[0] === m2[0] && +m1[1].transition.nodeData._id < +m2[1].transition.nodeData._id) ? -1 : 1;
+    }) 
+    .map(([, entityMatch]) => entityMatch);
 }

--- a/packages/change-analysis/lib/model-diffing/property-diff.ts
+++ b/packages/change-analysis/lib/model-diffing/property-diff.ts
@@ -14,6 +14,7 @@ import {
   MovePropertyComponentOperation,
   arrayIntersection, isDefined, stringSimilarity,
 } from 'cdk-change-analyzer-models';
+import { fromEntries } from '../private/node';
 import { propertySimilarityEvaluatorCreator } from './entity-matchers/component-properties-matcher';
 import { matchEntities } from './entity-matchers/entities-matcher';
 
@@ -149,8 +150,8 @@ export class PropertyDiffCreator {
       p2Array.map((_,i) => i),
       propertySimilarityEvaluatorCreator(
         this.componentTransition,
-        Object.fromEntries(p1Array.map((e, i) => [i, e])),
-        Object.fromEntries(p2Array.map((e, i) => [i, e])),
+        fromEntries(p1Array.map((e, i) => [i, e])),
+        fromEntries(p2Array.map((e, i) => [i, e])),
         pathP1, pathP2,
       ),
       propertySimilarityThreshold,

--- a/packages/change-analysis/lib/platform-mapping/cdk/cdk-parser.ts
+++ b/packages/change-analysis/lib/platform-mapping/cdk/cdk-parser.ts
@@ -3,6 +3,7 @@ import {
   ComponentPropertyAccessError,
   InfraModel,
 } from 'cdk-change-analyzer-models';
+import { flatMap } from '../../private/node';
 import { CFParser, CFParserArgs } from '../cloudformation';
 import { Parser } from '../parser';
 import { CDKConstruct } from './cdk-construct';
@@ -84,7 +85,7 @@ export class CDKParser implements Parser {
 
     const relationships = [
       ...cfInfraModel.relationships.filter(r => r.source !== cfInfraRoot),
-      ...constructs.flatMap(c => [...c.component.outgoing]),
+      ...flatMap(constructs, c => [...c.component.outgoing]),
     ];
 
     return new InfraModel(components, relationships);

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-entity.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-entity.ts
@@ -10,6 +10,7 @@ import {
   DependencyRelationshipOptions,
   PropertyPath,
 } from 'cdk-change-analyzer-models';
+import { fromEntries } from '../../private/node';
 import { CFParserArgs } from './cf-parser-args';
 import { CFRef } from './cf-ref';
 
@@ -105,7 +106,7 @@ export abstract class CFEntity {
           updateType,
         );
       } else if(typeof _definition === 'object' && _definition !== null) {
-        return new ComponentPropertyRecord(Object.fromEntries(
+        return new ComponentPropertyRecord(fromEntries(
           Object.entries(_definition).map(([propKey, propValue]) => {
             const newPropertyPath = [...propertyPath, propKey];
             return [propKey, factory(propValue, newPropertyPath)];

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-parser.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-parser.ts
@@ -1,4 +1,5 @@
 import { InfraModel, Component, StructuralRelationship } from 'cdk-change-analyzer-models';
+import { flatMap, fromEntries } from '../../private/node';
 import { Parser } from '../parser';
 import { CFEntity } from './cf-entity';
 import { CFNestedStack } from './cf-nested-stack';
@@ -49,12 +50,12 @@ export class CFParser implements Parser {
      */
   public createCFEntities(templateRoot: Component, args?: CFParserArgs):Record<string, CFEntity>[] {
     const entities: Record<string, CFEntity>[] = this.templates.map(template =>
-      Object.fromEntries(
-        Object.entries(template).flatMap(([componentType, definitions]) =>
+      fromEntries(
+        flatMap(Object.entries(template), ([componentType, definitions]) =>
           Object.entries(definitions).map(([componentName, definition]) =>
             [componentName, cfEntityFactory(componentType, componentName, definition, args ?? {})])
             .filter(e => e[1] !== undefined),
-        ),
+        ) as [string, CFEntity][]
       ),
     );
 

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-parser.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-parser.ts
@@ -55,8 +55,8 @@ export class CFParser implements Parser {
           Object.entries(definitions)
             .map(([componentName, definition]) =>
               [componentName, cfEntityFactory(componentType, componentName, definition, args ?? {})])
-            .filter(e => e[1] !== undefined) as [string, CFNestedStack | CFResource | CFParameter | CFOutput][]
-        )
+            .filter(e => e[1] !== undefined) as [string, CFNestedStack | CFResource | CFParameter | CFOutput][],
+        ),
       ),
     );
 

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-parser.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-parser.ts
@@ -52,10 +52,11 @@ export class CFParser implements Parser {
     const entities: Record<string, CFEntity>[] = this.templates.map(template =>
       fromEntries(
         flatMap(Object.entries(template), ([componentType, definitions]) =>
-          Object.entries(definitions).map(([componentName, definition]) =>
-            [componentName, cfEntityFactory(componentType, componentName, definition, args ?? {})])
-            .filter(e => e[1] !== undefined),
-        ) as [string, CFEntity][]
+          Object.entries(definitions)
+            .map(([componentName, definition]) =>
+              [componentName, cfEntityFactory(componentType, componentName, definition, args ?? {})])
+            .filter(e => e[1] !== undefined) as [string, CFNestedStack | CFResource | CFParameter | CFOutput][]
+        )
       ),
     );
 

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-ref.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-ref.ts
@@ -20,11 +20,11 @@ export class CFRef {
                   (typeof value[1] === 'object' && value[1] !== null)
                     || value[1] === undefined
                 ))
-        return [...value[0].matchAll(/\$\{[A-Za-z0-9.]*\}/g)]
-          .map(v => v[0].slice(2,-1))
+        return value[0].match(/\$\{[A-Za-z0-9.]*\}/g)
+          ?.map(v => v.slice(2,-1))
           .filter(v => !Object.keys(value[1])
             .includes(v),
-          ).map(r => new CFRef(path, r));
+          ).map(r => new CFRef(path, r)) ?? [];
       throw new CFRefInitError('Fn::Sub does not follow the right structure');
     },
   })

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-ref.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-ref.ts
@@ -15,16 +15,15 @@ export class CFRef {
     },
     'Fn::Sub': (path: PropertyPath, value: any) => {
       if(Array.isArray(value)
-                && typeof value[0] === 'string'
-                && (
-                  (typeof value[1] === 'object' && value[1] !== null)
-                    || value[1] === undefined
-                ))
+        && typeof value[0] === 'string'
+        && ((typeof value[1] === 'object' && value[1] !== null) || value[1] === undefined)
+      ) {
         return value[0].match(/\$\{[A-Za-z0-9.]*\}/g)
-          ?.map(v => v.slice(2,-1))
-          .filter(v => !Object.keys(value[1])
-            .includes(v),
-          ).map(r => new CFRef(path, r)) ?? [];
+          ?.map(v => v.slice(2, -1))
+          .filter(v => !Object.keys(value[1]).includes(v))
+          .map(r => new CFRef(path, r)) ?? [];
+      }
+        
       throw new CFRefInitError('Fn::Sub does not follow the right structure');
     },
   })

--- a/packages/change-analysis/lib/platform-mapping/cloudformation/cf-ref.ts
+++ b/packages/change-analysis/lib/platform-mapping/cloudformation/cf-ref.ts
@@ -23,7 +23,7 @@ export class CFRef {
           .filter(v => !Object.keys(value[1]).includes(v))
           .map(r => new CFRef(path, r)) ?? [];
       }
-        
+
       throw new CFRefInitError('Fn::Sub does not follow the right structure');
     },
   })

--- a/packages/change-analysis/lib/private/node.ts
+++ b/packages/change-analysis/lib/private/node.ts
@@ -1,0 +1,24 @@
+/**
+ * Map a function over an array and concatenate the results
+ */
+ export function flatMap<T, U>(xs: T[], fn: ((x: T, i: number) => U[])): U[] {
+  return flatten(xs.map(fn));
+}
+
+/**
+ * Flatten a list of lists into a list of elements
+ */
+export function flatten<T>(xs: T[][]): T[] {
+  return Array.prototype.concat.apply([], xs);
+}
+
+/**
+ * Creates an object representing the given iterable
+ * list of [key, value] pairs.
+ */
+export function fromEntries<T>(iterable: [string | number, T][]): {[key: string]: T}  {
+  return [...iterable].reduce((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {} as {[key: string]: T});
+}

--- a/packages/change-analysis/lib/private/node.ts
+++ b/packages/change-analysis/lib/private/node.ts
@@ -13,7 +13,7 @@ export function flatMap<T, U>(xs: T[], f: (x: T) => U[]): U[] {
  * Creates an object representing the given iterable
  * list of [key, value] pairs.
  */
-export function fromEntries(xs: [string|number|symbol, any][]) {
-  return xs.reduce((acc, [key, value]) => ({...acc, [key]: value}), {});
+export function fromEntries<T>(xs: [string|number|symbol, T][]): {[key: string]: T} {
+  return xs.reduce((acc, [key, value]) => ({ ...acc, [key]: value,}), {});
 }
  

--- a/packages/change-analysis/lib/private/node.ts
+++ b/packages/change-analysis/lib/private/node.ts
@@ -13,9 +13,7 @@ export function flatMap<T, U>(xs: T[], f: (x: T) => U[]): U[] {
  * Creates an object representing the given iterable
  * list of [key, value] pairs.
  */
-export function fromEntries<T>(iterable: [string | number, T][]): {[key: string]: T}  {
-  return [...iterable].reduce((obj, [key, val]) => {
-    obj[key] = val
-    return obj
-  }, {} as {[key: string]: T});
+export function fromEntries(xs: [string|number|symbol, any][]) {
+  return xs.reduce((acc, [key, value]) => ({...acc, [key]: value}), {});
 }
+ 

--- a/packages/change-analysis/lib/private/node.ts
+++ b/packages/change-analysis/lib/private/node.ts
@@ -1,15 +1,12 @@
 /**
  * Map a function over an array and concatenate the results
  */
- export function flatMap<T, U>(xs: T[], fn: ((x: T, i: number) => U[])): U[] {
-  return flatten(xs.map(fn));
-}
-
-/**
- * Flatten a list of lists into a list of elements
- */
-export function flatten<T>(xs: T[][]): T[] {
-  return Array.prototype.concat.apply([], xs);
+export function flatMap<T, U>(xs: T[], f: (x: T) => U[]): U[] {
+  const ret = new Array<U>();
+  for (const x of xs) {
+    ret.push(...f(x));
+  }
+  return ret;
 }
 
 /**

--- a/packages/change-analysis/lib/private/node.ts
+++ b/packages/change-analysis/lib/private/node.ts
@@ -14,6 +14,5 @@ export function flatMap<T, U>(xs: T[], f: (x: T) => U[]): U[] {
  * list of [key, value] pairs.
  */
 export function fromEntries<T>(xs: [string|number|symbol, T][]): {[key: string]: T} {
-  return xs.reduce((acc, [key, value]) => ({ ...acc, [key]: value,}), {});
+  return xs.reduce((acc, [key, value]) => ({ ...acc, [key]: value}), {});
 }
- 

--- a/packages/change-analysis/lib/security-changes.ts
+++ b/packages/change-analysis/lib/security-changes.ts
@@ -1,6 +1,7 @@
 import { OperationType, RuleRisk } from 'cdk-change-analyzer-models';
 import { IAM_POLICY_PROPERTIES, IAM_POLICY_RESOURCES } from './private/security-policies';
 import { CUserRule, CUserRules } from './user-configuration';
+import {flatMap} from './private/node';
 
 interface ChangeRuleOptions {
   target: string;
@@ -51,7 +52,7 @@ export class SecurityChangesRules {
       return rules._createResourceRule({
         identifier,
         resource,
-        then: policies.flatMap(policy => [
+        then: flatMap(policies, policy => [
           // Managed Policies
           {
             propertyOperationType: OperationType.INSERT,

--- a/packages/change-analysis/lib/security-changes.ts
+++ b/packages/change-analysis/lib/security-changes.ts
@@ -1,7 +1,7 @@
 import { OperationType, RuleRisk } from 'cdk-change-analyzer-models';
+import {flatMap} from './private/node';
 import { IAM_POLICY_PROPERTIES, IAM_POLICY_RESOURCES } from './private/security-policies';
 import { CUserRule, CUserRules } from './user-configuration';
-import {flatMap} from './private/node';
 
 interface ChangeRuleOptions {
   target: string;

--- a/packages/change-analysis/lib/user-configuration/apply-rules.ts
+++ b/packages/change-analysis/lib/user-configuration/apply-rules.ts
@@ -1,4 +1,5 @@
 import { ComponentOperation, InfraModelDiff, PropertyComponentOperation, RuleEffect } from 'cdk-change-analyzer-models';
+import { flatMap } from '../private/node';
 import { CUserRules } from './rule-config-schema';
 import { parseRules } from './rule-parser';
 import { RuleProcessor } from './rule-processor';
@@ -6,12 +7,14 @@ import { RuleProcessor } from './rule-processor';
 export function applyRules(diff: InfraModelDiff, cRules: CUserRules): Map<ComponentOperation, RuleEffect> {
 
   const rules = parseRules(cRules);
-  const idToOpMap = new Map(diff.componentOperations
-    .flatMap(op => op instanceof PropertyComponentOperation ? op.explode() : [op]).map(op => [op.nodeData._id, op]));
+  const idToOpMap = new Map(flatMap(
+    diff.componentOperations,
+    op =>op instanceof PropertyComponentOperation ? op.explode() : [op]).map(op => [op.nodeData._id, op],
+  ));
 
   const verticesMap = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
 
-  return new Map([...verticesMap].flatMap(([vertex, effect]): [ComponentOperation, RuleEffect][] => {
+  return new Map(flatMap([...verticesMap], ([vertex, effect]): [ComponentOperation, RuleEffect][] => {
     const op = idToOpMap.get(vertex._id);
     if(op === undefined) return [];
     // exploding property operations - effects on property operations also affects the operations of inner properties

--- a/packages/change-analysis/lib/user-configuration/rule-parser.ts
+++ b/packages/change-analysis/lib/user-configuration/rule-parser.ts
@@ -1,4 +1,5 @@
 import { isDefined, ModelEntityTypes } from 'cdk-change-analyzer-models';
+import { fromEntries } from '../private/node';
 import { ConditionInput, RuleCondition, RuleConditionOperator, RuleConditions, Selector, SelectorFilter, UserRule, RuleScopeReference, RuleEffectDefinition } from './rule';
 import { CBindings, CSelector, CUserRule, isPathCSelector, ComponentCFilter, CRuleConditions, isComponentCFilter, GeneralCSelector, CRuleEffectDefinition } from './rule-config-schema';
 
@@ -22,7 +23,7 @@ function parseRule(rule: CUserRule): UserRule {
 
 function parseBindings(bindings?: CBindings){
   if(!bindings) return {};
-  return Object.fromEntries(
+  return fromEntries(
     Object.entries(bindings).map(([identifier, cselector]) =>
       [identifier, parseSelector(cselector)]),
   );

--- a/packages/change-analysis/lib/user-configuration/rule-processor.ts
+++ b/packages/change-analysis/lib/user-configuration/rule-processor.ts
@@ -51,7 +51,7 @@ export class RuleProcessor {
   }
 
   private processRulesWithScope(rules: UserRules, scope: RulesScope): RuleOutput {
-    return new Map([...flatMap(rules, r => [...this.processRule(r, scope)])])
+    return new Map([...flatMap(rules, r => [...this.processRule(r, scope)])]);
   }
 
   private processRule(rule: UserRule, currentScope: RulesScope): RuleOutput{

--- a/packages/change-analysis/package.json
+++ b/packages/change-analysis/package.json
@@ -13,7 +13,7 @@
     "clean": "npx tsc --build --clean",
     "clean:all": "git clean -fdx",
     "lint": "eslint . --ext .ts",
-    "test": "jest"
+    "test": "npx jest"
   },
   "repository": {
     "type": "git",

--- a/packages/change-analysis/package.json
+++ b/packages/change-analysis/package.json
@@ -25,6 +25,9 @@
     "url": "https://aws.amazon.com",
     "organization": true
   },
+  "engines": {
+    "node": ">= 10.13.0 <13 || >=13.7.0"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-cdk/cfnspec": "^1.115.0",
@@ -39,7 +42,7 @@
     "minimatch": "^3.0.4",
     "semver": "^7.3.5",
     "yaml": "^1.10.2",
-    "yargs": "^17.0.1"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "@aws-cdk/aws-appsync": "^1.115.0",

--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -9,6 +9,9 @@
   },
   "keywords": [],
   "author": "",
+  "engines": {
+    "node": ">= 10.13.0 <13 || >=13.7.0"
+  },
   "license": "ISC",
   "dependencies": {
     "@material-ui/core": "^4.11.3",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2018",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["es2018", "dom"],
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11236,19 +11236,6 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz#6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb"
-  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"


### PR DESCRIPTION
* Create Node 12.x functions `fromEntries` and `flatMap` and substitute out.
* Adjust the sort function in `change-analysis/lib/model-diffing/entity-matchers` to sort by the numerical value of node id's (Turns out from node 10 to node 12, the V8 stabilized sort  to go from quicksort in v10  to Timsort in v12 ([blog post](https://v8.dev/blog/array-sort)). And previous implementation implicitly depends on the starting order of the input)
* Make `--rules-path` to be optional and create warning if rules length is empty