### PR TITLE
fix: change _entityType node data property to entityType

### DIFF
--- a/packages/change-analysis-models/infra-model/model-entity.ts
+++ b/packages/change-analysis-models/infra-model/model-entity.ts
@@ -14,11 +14,11 @@ export class ModelEntity<
 
     static idCounter = 0;
 
-    public readonly nodeData: fn.VertexProps<ND>;
+    public readonly nodeData: fn.VertexProps<ND> & { entityType: string };
     protected readonly outgoingNodeReferences: OR;
 
     constructor(entityType: string, nodeData: fn.InVertex<ND>, outgoingNodeReferences: OR){
-        this.nodeData = {_entityType: entityType, _id: `${++ModelEntity.idCounter}`, ...nodeData};
+        this.nodeData = { entityType, _id: `${++ModelEntity.idCounter}`, ...nodeData};
         this.outgoingNodeReferences = outgoingNodeReferences; 
     }
 

--- a/packages/change-analysis/lib/user-configuration/rule-parser.ts
+++ b/packages/change-analysis/lib/user-configuration/rule-parser.ts
@@ -67,7 +67,7 @@ function parseGeneralFilter(selector: GeneralCSelector): SelectorFilter {
 
   return {
     ...selector[keys[0]],
-    _entityType: keys[0],
+    entityType: keys[0],
   };
 }
 
@@ -88,7 +88,7 @@ function parseComponentCFilter(selector: ComponentCFilter): SelectorFilter {
   }
 
   return {
-    _entityType: ModelEntityTypes.component,
+    entityType: ModelEntityTypes.component,
     type,
     ...subtype ? {subtype} : {},
     ...name ? {name} : {},

--- a/packages/change-analysis/lib/user-configuration/rule.ts
+++ b/packages/change-analysis/lib/user-configuration/rule.ts
@@ -43,7 +43,7 @@ export type RuleScopeReference = {
 export type SelectorFilter = {
   [key: string]: Scalar,
 } & {
-  _entityType: string,
+  entityType: string,
 }
 
 export type Selector = ({

--- a/packages/change-analysis/test/model-diffing/__snapshots__/component-matching.test.ts.snap
+++ b/packages/change-analysis/test/model-diffing/__snapshots__/component-matching.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Matching basic template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"diff\\",
+        \\"entityType\\": \\"diff\\",
         \\"_id\\": \\"1055\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"componentOperations\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"365\\",
                     \\"type\\": \\"REMOVE\\"
                 },
@@ -18,7 +18,7 @@ exports[`Matching basic template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"21\\",
                                 \\"name\\": \\"Table1725C6B72\\",
                                 \\"type\\": \\"Resource\\",
@@ -56,7 +56,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"364\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -71,7 +71,7 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"340\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -129,7 +129,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"338\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -139,7 +139,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"339\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -150,13 +150,13 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"323\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"40\\",
                                     \\"name\\": \\"ConstructWithTableTable14C141063\\",
                                     \\"type\\": \\"Resource\\",
@@ -170,7 +170,7 @@ exports[`Matching basic template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"195\\",
                                     \\"name\\": \\"ConstructWithTableTable14C141063\\",
                                     \\"type\\": \\"Resource\\",
@@ -188,7 +188,7 @@ exports[`Matching basic template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"337\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -200,7 +200,7 @@ exports[`Matching basic template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"335\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -214,7 +214,7 @@ exports[`Matching basic template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"336\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -227,7 +227,7 @@ exports[`Matching basic template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"333\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -239,7 +239,7 @@ exports[`Matching basic template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"331\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -255,7 +255,7 @@ exports[`Matching basic template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"332\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -268,7 +268,7 @@ exports[`Matching basic template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"330\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -280,7 +280,7 @@ exports[`Matching basic template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"328\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -298,7 +298,7 @@ exports[`Matching basic template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"329\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -311,7 +311,7 @@ exports[`Matching basic template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"327\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -323,7 +323,7 @@ exports[`Matching basic template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"325\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -343,7 +343,7 @@ exports[`Matching basic template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"326\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -399,7 +399,7 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"363\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -451,7 +451,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"361\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -461,7 +461,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"362\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -472,13 +472,13 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"343\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"57\\",
                                     \\"name\\": \\"Table2DBDCD1F7\\",
                                     \\"type\\": \\"Resource\\",
@@ -492,7 +492,7 @@ exports[`Matching basic template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"212\\",
                                     \\"name\\": \\"Table2DBDCD1F7\\",
                                     \\"type\\": \\"Resource\\",
@@ -510,7 +510,7 @@ exports[`Matching basic template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"360\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -522,7 +522,7 @@ exports[`Matching basic template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"358\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -536,7 +536,7 @@ exports[`Matching basic template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"359\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -549,7 +549,7 @@ exports[`Matching basic template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"353\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -561,7 +561,7 @@ exports[`Matching basic template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"351\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -577,7 +577,7 @@ exports[`Matching basic template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"352\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -590,7 +590,7 @@ exports[`Matching basic template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"350\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -602,7 +602,7 @@ exports[`Matching basic template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"348\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -620,7 +620,7 @@ exports[`Matching basic template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"349\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -633,7 +633,7 @@ exports[`Matching basic template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"347\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -645,7 +645,7 @@ exports[`Matching basic template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"345\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -665,7 +665,7 @@ exports[`Matching basic template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"346\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -703,7 +703,7 @@ exports[`Matching basic template 1`] = `
                                     },
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"357\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -715,7 +715,7 @@ exports[`Matching basic template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"355\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -731,7 +731,7 @@ exports[`Matching basic template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"356\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -769,7 +769,7 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"1052\\",
                     \\"type\\": \\"REMOVE\\"
                 },
@@ -777,7 +777,7 @@ exports[`Matching basic template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"115\\",
                                 \\"name\\": \\"Resource\\",
                                 \\"type\\": \\"CDK Construct\\"
@@ -793,7 +793,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"1051\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -808,7 +808,7 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"1054\\",
                     \\"type\\": \\"REMOVE\\"
                 },
@@ -816,7 +816,7 @@ exports[`Matching basic template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"139\\",
                                 \\"name\\": \\"Table1\\",
                                 \\"type\\": \\"CDK Construct\\"
@@ -832,7 +832,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"1053\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -852,13 +852,13 @@ exports[`Matching basic template 1`] = `
             \\"[dup-ref]2\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"366\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"62\\",
                             \\"name\\": \\"user2C2B57AE\\",
                             \\"type\\": \\"Resource\\",
@@ -875,7 +875,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"217\\",
                             \\"name\\": \\"user2C2B57AE\\",
                             \\"type\\": \\"Resource\\",
@@ -895,13 +895,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"367\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"95\\",
                             \\"name\\": \\"userDefaultPolicy083DF682\\",
                             \\"type\\": \\"Resource\\",
@@ -957,7 +957,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"250\\",
                             \\"name\\": \\"userDefaultPolicy083DF682\\",
                             \\"type\\": \\"Resource\\",
@@ -1016,13 +1016,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"780\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"103\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"Resource\\",
@@ -1043,7 +1043,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"258\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"Resource\\",
@@ -1067,13 +1067,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"817\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"119\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1088,7 +1088,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"269\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1106,13 +1106,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"854\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"123\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1127,7 +1127,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"273\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1145,13 +1145,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"891\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"127\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1166,7 +1166,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"277\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1184,13 +1184,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"928\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"131\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1205,7 +1205,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"281\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1223,13 +1223,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"941\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"135\\",
                             \\"name\\": \\"Default\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1244,7 +1244,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"285\\",
                             \\"name\\": \\"Default\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1262,13 +1262,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"974\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"142\\",
                             \\"name\\": \\"HelloCdkStack\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1283,7 +1283,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"295\\",
                             \\"name\\": \\"HelloCdkStack\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1301,13 +1301,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"984\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"147\\",
                             \\"name\\": \\"Table1\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1322,7 +1322,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"289\\",
                             \\"name\\": \\"Table1\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1340,13 +1340,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"997\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"150\\",
                             \\"name\\": \\"ConstructWithTable\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1361,7 +1361,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"292\\",
                             \\"name\\": \\"ConstructWithTable\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1379,13 +1379,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"1011\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"156\\",
                             \\"name\\": \\"Table2\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1400,7 +1400,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"301\\",
                             \\"name\\": \\"Table2\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1418,13 +1418,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"1024\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"161\\",
                             \\"name\\": \\"user\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1439,7 +1439,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"306\\",
                             \\"name\\": \\"user\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1457,13 +1457,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"1037\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"166\\",
                             \\"name\\": \\"DefaultPolicy\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1478,7 +1478,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"311\\",
                             \\"name\\": \\"DefaultPolicy\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1496,13 +1496,13 @@ exports[`Matching basic template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"1050\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"171\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1517,7 +1517,7 @@ exports[`Matching basic template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"316\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -1538,13 +1538,13 @@ exports[`Matching basic template 1`] = `
         ],
         \\"infraModelTransition\\": {
             \\"nodeData\\": {
-                \\"_entityType\\": \\"transition\\",
+                \\"entityType\\": \\"transition\\",
                 \\"_id\\": \\"320\\"
             },
             \\"outgoingNodeReferences\\": {
                 \\"v1\\": {
                     \\"nodeData\\": {
-                        \\"_entityType\\": \\"infrastructureState\\",
+                        \\"entityType\\": \\"infrastructureState\\",
                         \\"_id\\": \\"174\\"
                     },
                     \\"outgoingNodeReferences\\": {
@@ -1573,7 +1573,7 @@ exports[`Matching basic template 1`] = `
                         \\"relationships\\": [
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"111\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> Table2DBDCD1F7.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -1596,7 +1596,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"112\\",
                                     \\"type\\": \\"Properties.Users.0.Ref -> user2C2B57AE\\",
                                     \\"sourcePropertyPath\\": [
@@ -1614,7 +1614,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"116\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1625,7 +1625,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"120\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1636,7 +1636,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"124\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1647,7 +1647,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"128\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1658,7 +1658,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"132\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1669,7 +1669,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"136\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1680,7 +1680,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"144\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1691,7 +1691,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"143\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1702,7 +1702,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"151\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1713,7 +1713,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"157\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1724,7 +1724,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"162\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1735,7 +1735,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"172\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1746,7 +1746,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"153\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1757,7 +1757,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"152\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1768,7 +1768,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"158\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1779,7 +1779,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"163\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1790,7 +1790,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"167\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1801,7 +1801,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"168\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1812,7 +1812,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"173\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1826,7 +1826,7 @@ exports[`Matching basic template 1`] = `
                 },
                 \\"v2\\": {
                     \\"nodeData\\": {
-                        \\"_entityType\\": \\"infrastructureState\\",
+                        \\"entityType\\": \\"infrastructureState\\",
                         \\"_id\\": \\"319\\"
                     },
                     \\"outgoingNodeReferences\\": {
@@ -1852,7 +1852,7 @@ exports[`Matching basic template 1`] = `
                         \\"relationships\\": [
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"265\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> Table2DBDCD1F7.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -1875,7 +1875,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"266\\",
                                     \\"type\\": \\"Properties.Users.0.Ref -> user2C2B57AE\\",
                                     \\"sourcePropertyPath\\": [
@@ -1893,7 +1893,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"270\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1904,7 +1904,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"274\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1915,7 +1915,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"278\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1926,7 +1926,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"282\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1937,7 +1937,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"286\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -1948,7 +1948,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"298\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1959,7 +1959,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"297\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1970,7 +1970,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"296\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1981,7 +1981,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"302\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -1992,7 +1992,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"307\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2003,7 +2003,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"317\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2014,7 +2014,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"303\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2025,7 +2025,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"308\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2036,7 +2036,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"312\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2047,7 +2047,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"313\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2058,7 +2058,7 @@ exports[`Matching basic template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"318\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -2082,14 +2082,14 @@ exports[`Matching basic template 1`] = `
 exports[`Matching big template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"diff\\",
+        \\"entityType\\": \\"diff\\",
         \\"_id\\": \\"17872\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"componentOperations\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"4012\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -2147,7 +2147,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4010\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -2157,7 +2157,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4011\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -2168,13 +2168,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"3995\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1204\\",
                                     \\"name\\": \\"InstanceInstanceRoleE9785DE5\\",
                                     \\"type\\": \\"Resource\\",
@@ -2188,7 +2188,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2543\\",
                                     \\"name\\": \\"InstanceInstanceRoleE9785DE5\\",
                                     \\"type\\": \\"Resource\\",
@@ -2206,7 +2206,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"4009\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -2218,7 +2218,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4007\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -2232,7 +2232,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4008\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -2245,7 +2245,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"4006\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -2257,7 +2257,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4004\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -2273,7 +2273,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4005\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -2286,7 +2286,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"4003\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -2298,7 +2298,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4001\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -2316,7 +2316,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4002\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -2329,7 +2329,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"4000\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -2341,7 +2341,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"3998\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -2361,7 +2361,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"3999\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -2417,7 +2417,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"4699\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -2585,7 +2585,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4697\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -2595,7 +2595,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4698\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -2606,13 +2606,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4445\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1643\\",
                                     \\"name\\": \\"WebAppLambdaE4C4A83F\\",
                                     \\"type\\": \\"Resource\\",
@@ -2626,7 +2626,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2854\\",
                                     \\"name\\": \\"WebAppLambdaE4C4A83F\\",
                                     \\"type\\": \\"Resource\\",
@@ -2644,7 +2644,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"4680\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -2656,7 +2656,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4678\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -2670,7 +2670,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4679\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -2683,7 +2683,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"4647\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -2695,7 +2695,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4645\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -2711,7 +2711,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4646\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -2724,7 +2724,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"4451\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -2736,7 +2736,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4449\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -2754,7 +2754,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4450\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -2767,7 +2767,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"4448\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -2779,7 +2779,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"4446\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -2799,7 +2799,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"4447\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -2828,7 +2828,7 @@ exports[`Matching big template 1`] = `
                                                 },
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"4644\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -2840,7 +2840,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4642\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -2858,7 +2858,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4643\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -2871,7 +2871,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"4641\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -2883,7 +2883,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"4639\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -2903,7 +2903,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"4640\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -2916,7 +2916,7 @@ exports[`Matching big template 1`] = `
                                                                     \\"innerOperations\\": [
                                                                         {
                                                                             \\"nodeData\\": {
-                                                                                \\"_entityType\\": \\"change\\",
+                                                                                \\"entityType\\": \\"change\\",
                                                                                 \\"_id\\": \\"4638\\",
                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                 \\"type\\": \\"UPDATE\\"
@@ -2928,7 +2928,7 @@ exports[`Matching big template 1`] = `
                                                                                 },
                                                                                 \\"pathTransition\\": {
                                                                                     \\"nodeData\\": {
-                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                        \\"entityType\\": \\"transition\\",
                                                                                         \\"_id\\": \\"4636\\",
                                                                                         \\"v1\\": [
                                                                                             \\"Properties\\",
@@ -2950,7 +2950,7 @@ exports[`Matching big template 1`] = `
                                                                                 },
                                                                                 \\"propertyTransition\\": {
                                                                                     \\"nodeData\\": {
-                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                        \\"entityType\\": \\"transition\\",
                                                                                         \\"_id\\": \\"4637\\"
                                                                                     },
                                                                                     \\"outgoingNodeReferences\\": {
@@ -2963,7 +2963,7 @@ exports[`Matching big template 1`] = `
                                                                                 \\"innerOperations\\": [
                                                                                     {
                                                                                         \\"nodeData\\": {
-                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                            \\"entityType\\": \\"change\\",
                                                                                             \\"_id\\": \\"4500\\",
                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                             \\"type\\": \\"UPDATE\\"
@@ -2975,7 +2975,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"pathTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"4498\\",
                                                                                                     \\"v1\\": [
                                                                                                         \\"Properties\\",
@@ -2999,7 +2999,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"propertyTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"4499\\"
                                                                                                 },
                                                                                                 \\"outgoingNodeReferences\\": {
@@ -3012,7 +3012,7 @@ exports[`Matching big template 1`] = `
                                                                                             \\"innerOperations\\": [
                                                                                                 {
                                                                                                     \\"nodeData\\": {
-                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                         \\"_id\\": \\"4497\\",
                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -3024,7 +3024,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"pathTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"4495\\",
                                                                                                                 \\"v1\\": [
                                                                                                                     \\"Properties\\",
@@ -3050,7 +3050,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"propertyTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"4496\\"
                                                                                                             },
                                                                                                             \\"outgoingNodeReferences\\": {
@@ -3063,7 +3063,7 @@ exports[`Matching big template 1`] = `
                                                                                                         \\"innerOperations\\": [
                                                                                                             {
                                                                                                                 \\"nodeData\\": {
-                                                                                                                    \\"_entityType\\": \\"change\\",
+                                                                                                                    \\"entityType\\": \\"change\\",
                                                                                                                     \\"_id\\": \\"4494\\",
                                                                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                     \\"type\\": \\"UPDATE\\"
@@ -3075,7 +3075,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"pathTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"4492\\",
                                                                                                                             \\"v1\\": [
                                                                                                                                 \\"Properties\\",
@@ -3103,7 +3103,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"propertyTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"4493\\"
                                                                                                                         },
                                                                                                                         \\"outgoingNodeReferences\\": {
@@ -3116,7 +3116,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     \\"innerOperations\\": [
                                                                                                                         {
                                                                                                                             \\"nodeData\\": {
-                                                                                                                                \\"_entityType\\": \\"change\\",
+                                                                                                                                \\"entityType\\": \\"change\\",
                                                                                                                                 \\"_id\\": \\"4491\\",
                                                                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                 \\"type\\": \\"UPDATE\\"
@@ -3128,7 +3128,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"pathTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"4489\\",
                                                                                                                                         \\"v1\\": [
                                                                                                                                             \\"Properties\\",
@@ -3158,7 +3158,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"propertyTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"4490\\"
                                                                                                                                     },
                                                                                                                                     \\"outgoingNodeReferences\\": {
@@ -3171,7 +3171,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 \\"innerOperations\\": [
                                                                                                                                     {
                                                                                                                                         \\"nodeData\\": {
-                                                                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                                                                            \\"entityType\\": \\"change\\",
                                                                                                                                             \\"_id\\": \\"4488\\",
                                                                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                             \\"type\\": \\"UPDATE\\"
@@ -3183,7 +3183,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"pathTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"4486\\",
                                                                                                                                                     \\"v1\\": [
                                                                                                                                                         \\"Properties\\",
@@ -3215,7 +3215,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"propertyTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"4487\\"
                                                                                                                                                 },
                                                                                                                                                 \\"outgoingNodeReferences\\": {
@@ -3228,7 +3228,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             \\"innerOperations\\": [
                                                                                                                                                 {
                                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                                                                         \\"_id\\": \\"4485\\",
                                                                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -3240,7 +3240,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"pathTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"4483\\",
                                                                                                                                                                 \\"v1\\": [
                                                                                                                                                                     \\"Properties\\",
@@ -3274,7 +3274,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"propertyTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"4484\\"
                                                                                                                                                             },
                                                                                                                                                             \\"outgoingNodeReferences\\": {
@@ -3339,7 +3339,7 @@ exports[`Matching big template 1`] = `
                                                                                     },
                                                                                     {
                                                                                         \\"nodeData\\": {
-                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                            \\"entityType\\": \\"change\\",
                                                                                             \\"_id\\": \\"4635\\",
                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                             \\"type\\": \\"UPDATE\\"
@@ -3351,7 +3351,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"pathTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"4633\\",
                                                                                                     \\"v1\\": [
                                                                                                         \\"Properties\\",
@@ -3375,7 +3375,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"propertyTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"4634\\"
                                                                                                 },
                                                                                                 \\"outgoingNodeReferences\\": {
@@ -3388,7 +3388,7 @@ exports[`Matching big template 1`] = `
                                                                                             \\"innerOperations\\": [
                                                                                                 {
                                                                                                     \\"nodeData\\": {
-                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                         \\"_id\\": \\"4632\\",
                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -3400,7 +3400,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"pathTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"4630\\",
                                                                                                                 \\"v1\\": [
                                                                                                                     \\"Properties\\",
@@ -3426,7 +3426,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"propertyTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"4631\\"
                                                                                                             },
                                                                                                             \\"outgoingNodeReferences\\": {
@@ -3439,7 +3439,7 @@ exports[`Matching big template 1`] = `
                                                                                                         \\"innerOperations\\": [
                                                                                                             {
                                                                                                                 \\"nodeData\\": {
-                                                                                                                    \\"_entityType\\": \\"change\\",
+                                                                                                                    \\"entityType\\": \\"change\\",
                                                                                                                     \\"_id\\": \\"4629\\",
                                                                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                     \\"type\\": \\"UPDATE\\"
@@ -3451,7 +3451,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"pathTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"4627\\",
                                                                                                                             \\"v1\\": [
                                                                                                                                 \\"Properties\\",
@@ -3479,7 +3479,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"propertyTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"4628\\"
                                                                                                                         },
                                                                                                                         \\"outgoingNodeReferences\\": {
@@ -3492,7 +3492,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     \\"innerOperations\\": [
                                                                                                                         {
                                                                                                                             \\"nodeData\\": {
-                                                                                                                                \\"_entityType\\": \\"change\\",
+                                                                                                                                \\"entityType\\": \\"change\\",
                                                                                                                                 \\"_id\\": \\"4626\\",
                                                                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                 \\"type\\": \\"UPDATE\\"
@@ -3504,7 +3504,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"pathTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"4624\\",
                                                                                                                                         \\"v1\\": [
                                                                                                                                             \\"Properties\\",
@@ -3534,7 +3534,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"propertyTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"4625\\"
                                                                                                                                     },
                                                                                                                                     \\"outgoingNodeReferences\\": {
@@ -3547,7 +3547,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 \\"innerOperations\\": [
                                                                                                                                     {
                                                                                                                                         \\"nodeData\\": {
-                                                                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                                                                            \\"entityType\\": \\"change\\",
                                                                                                                                             \\"_id\\": \\"4623\\",
                                                                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                             \\"type\\": \\"UPDATE\\"
@@ -3559,7 +3559,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"pathTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"4621\\",
                                                                                                                                                     \\"v1\\": [
                                                                                                                                                         \\"Properties\\",
@@ -3591,7 +3591,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"propertyTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"4622\\"
                                                                                                                                                 },
                                                                                                                                                 \\"outgoingNodeReferences\\": {
@@ -3604,7 +3604,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             \\"innerOperations\\": [
                                                                                                                                                 {
                                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                                                                         \\"_id\\": \\"4620\\",
                                                                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -3616,7 +3616,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"pathTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"4618\\",
                                                                                                                                                                 \\"v1\\": [
                                                                                                                                                                     \\"Properties\\",
@@ -3650,7 +3650,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"propertyTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"4619\\"
                                                                                                                                                             },
                                                                                                                                                             \\"outgoingNodeReferences\\": {
@@ -3760,7 +3760,7 @@ exports[`Matching big template 1`] = `
                         },
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"4696\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -3772,7 +3772,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4694\\",
                                         \\"v1\\": [
                                             \\"Metadata\\"
@@ -3786,7 +3786,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4695\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -3799,7 +3799,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"4693\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -3811,7 +3811,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4691\\",
                                                     \\"v1\\": [
                                                         \\"Metadata\\",
@@ -3827,7 +3827,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4692\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -3865,7 +3865,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"4723\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -3931,7 +3931,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4721\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -3941,7 +3941,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4722\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -3952,13 +3952,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4702\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1186\\",
                                     \\"name\\": \\"InstanceInstanceSecurityGroupF0E2D5BE\\",
                                     \\"type\\": \\"Resource\\",
@@ -3972,7 +3972,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2525\\",
                                     \\"name\\": \\"InstanceInstanceSecurityGroupF0E2D5BE\\",
                                     \\"type\\": \\"Resource\\",
@@ -3990,7 +3990,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"4720\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -4002,7 +4002,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4718\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -4016,7 +4016,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"4719\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -4029,7 +4029,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"4705\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -4041,7 +4041,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4703\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -4057,7 +4057,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4704\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -4077,7 +4077,7 @@ exports[`Matching big template 1`] = `
                                     },
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"4717\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -4089,7 +4089,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4715\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -4105,7 +4105,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"4716\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -4118,7 +4118,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"4714\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -4130,7 +4130,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4712\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -4148,7 +4148,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"4713\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -4161,7 +4161,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"4711\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -4173,7 +4173,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"4709\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -4193,7 +4193,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"4710\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -4249,7 +4249,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"6200\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -4441,7 +4441,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"6198\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -4451,7 +4451,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"6199\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -4462,13 +4462,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"4743\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1455\\",
                                     \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
                                     \\"type\\": \\"Resource\\",
@@ -4482,7 +4482,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3337\\",
                                     \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
                                     \\"type\\": \\"Resource\\",
@@ -4500,7 +4500,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"6197\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -4512,7 +4512,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"6195\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -4526,7 +4526,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"6196\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -4539,7 +4539,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"6193\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -4551,7 +4551,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"6191\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -4567,7 +4567,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"6192\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -4580,7 +4580,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"6190\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -4592,7 +4592,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"6188\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -4610,7 +4610,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"6189\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -4623,7 +4623,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"5184\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -4635,7 +4635,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"5182\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -4655,7 +4655,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"5183\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -4668,7 +4668,7 @@ exports[`Matching big template 1`] = `
                                                                     \\"innerOperations\\": [
                                                                         {
                                                                             \\"nodeData\\": {
-                                                                                \\"_entityType\\": \\"change\\",
+                                                                                \\"entityType\\": \\"change\\",
                                                                                 \\"_id\\": \\"5181\\",
                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                 \\"type\\": \\"UPDATE\\"
@@ -4680,7 +4680,7 @@ exports[`Matching big template 1`] = `
                                                                                 },
                                                                                 \\"pathTransition\\": {
                                                                                     \\"nodeData\\": {
-                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                        \\"entityType\\": \\"transition\\",
                                                                                         \\"_id\\": \\"5179\\",
                                                                                         \\"v1\\": [
                                                                                             \\"Properties\\",
@@ -4702,7 +4702,7 @@ exports[`Matching big template 1`] = `
                                                                                 },
                                                                                 \\"propertyTransition\\": {
                                                                                     \\"nodeData\\": {
-                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                        \\"entityType\\": \\"transition\\",
                                                                                         \\"_id\\": \\"5180\\"
                                                                                     },
                                                                                     \\"outgoingNodeReferences\\": {
@@ -4715,7 +4715,7 @@ exports[`Matching big template 1`] = `
                                                                                 \\"innerOperations\\": [
                                                                                     {
                                                                                         \\"nodeData\\": {
-                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                            \\"entityType\\": \\"change\\",
                                                                                             \\"_id\\": \\"5178\\",
                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                             \\"type\\": \\"UPDATE\\"
@@ -4727,7 +4727,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"pathTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"5176\\",
                                                                                                     \\"v1\\": [
                                                                                                         \\"Properties\\",
@@ -4751,7 +4751,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"propertyTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"5177\\"
                                                                                                 },
                                                                                                 \\"outgoingNodeReferences\\": {
@@ -4764,7 +4764,7 @@ exports[`Matching big template 1`] = `
                                                                                             \\"innerOperations\\": [
                                                                                                 {
                                                                                                     \\"nodeData\\": {
-                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                         \\"_id\\": \\"5175\\",
                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -4776,7 +4776,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"pathTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"5173\\",
                                                                                                                 \\"v1\\": [
                                                                                                                     \\"Properties\\",
@@ -4802,7 +4802,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"propertyTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"5174\\"
                                                                                                             },
                                                                                                             \\"outgoingNodeReferences\\": {
@@ -4815,7 +4815,7 @@ exports[`Matching big template 1`] = `
                                                                                                         \\"innerOperations\\": [
                                                                                                             {
                                                                                                                 \\"nodeData\\": {
-                                                                                                                    \\"_entityType\\": \\"change\\",
+                                                                                                                    \\"entityType\\": \\"change\\",
                                                                                                                     \\"_id\\": \\"5172\\",
                                                                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                     \\"type\\": \\"UPDATE\\"
@@ -4827,7 +4827,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"pathTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"5170\\",
                                                                                                                             \\"v1\\": [
                                                                                                                                 \\"Properties\\",
@@ -4855,7 +4855,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"propertyTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"5171\\"
                                                                                                                         },
                                                                                                                         \\"outgoingNodeReferences\\": {
@@ -4868,7 +4868,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     \\"innerOperations\\": [
                                                                                                                         {
                                                                                                                             \\"nodeData\\": {
-                                                                                                                                \\"_entityType\\": \\"change\\",
+                                                                                                                                \\"entityType\\": \\"change\\",
                                                                                                                                 \\"_id\\": \\"5148\\",
                                                                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                 \\"type\\": \\"UPDATE\\"
@@ -4880,7 +4880,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"pathTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"5146\\",
                                                                                                                                         \\"v1\\": [
                                                                                                                                             \\"Properties\\",
@@ -4910,7 +4910,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"propertyTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"5147\\"
                                                                                                                                     },
                                                                                                                                     \\"outgoingNodeReferences\\": {
@@ -4923,7 +4923,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 \\"innerOperations\\": [
                                                                                                                                     {
                                                                                                                                         \\"nodeData\\": {
-                                                                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                                                                            \\"entityType\\": \\"change\\",
                                                                                                                                             \\"_id\\": \\"5145\\",
                                                                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                             \\"type\\": \\"UPDATE\\"
@@ -4935,7 +4935,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"pathTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"5143\\",
                                                                                                                                                     \\"v1\\": [
                                                                                                                                                         \\"Properties\\",
@@ -4967,7 +4967,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"propertyTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"5144\\"
                                                                                                                                                 },
                                                                                                                                                 \\"outgoingNodeReferences\\": {
@@ -5023,7 +5023,7 @@ exports[`Matching big template 1`] = `
                                                                                     },
                                                                                     {
                                                                                         \\"nodeData\\": {
-                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                            \\"entityType\\": \\"change\\",
                                                                                             \\"_id\\": \\"4855\\",
                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                             \\"type\\": \\"UPDATE\\"
@@ -5035,7 +5035,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"pathTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"4853\\",
                                                                                                     \\"v1\\": [
                                                                                                         \\"Properties\\",
@@ -5059,7 +5059,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"propertyTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"4854\\"
                                                                                                 },
                                                                                                 \\"outgoingNodeReferences\\": {
@@ -5072,7 +5072,7 @@ exports[`Matching big template 1`] = `
                                                                                             \\"innerOperations\\": [
                                                                                                 {
                                                                                                     \\"nodeData\\": {
-                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                         \\"_id\\": \\"4852\\",
                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -5084,7 +5084,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"pathTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"4850\\",
                                                                                                                 \\"v1\\": [
                                                                                                                     \\"Properties\\",
@@ -5110,7 +5110,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"propertyTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"4851\\"
                                                                                                             },
                                                                                                             \\"outgoingNodeReferences\\": {
@@ -5123,7 +5123,7 @@ exports[`Matching big template 1`] = `
                                                                                                         \\"innerOperations\\": [
                                                                                                             {
                                                                                                                 \\"nodeData\\": {
-                                                                                                                    \\"_entityType\\": \\"change\\",
+                                                                                                                    \\"entityType\\": \\"change\\",
                                                                                                                     \\"_id\\": \\"4849\\",
                                                                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                     \\"type\\": \\"UPDATE\\"
@@ -5135,7 +5135,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"pathTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"4847\\",
                                                                                                                             \\"v1\\": [
                                                                                                                                 \\"Properties\\",
@@ -5163,7 +5163,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"propertyTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"4848\\"
                                                                                                                         },
                                                                                                                         \\"outgoingNodeReferences\\": {
@@ -5176,7 +5176,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     \\"innerOperations\\": [
                                                                                                                         {
                                                                                                                             \\"nodeData\\": {
-                                                                                                                                \\"_entityType\\": \\"change\\",
+                                                                                                                                \\"entityType\\": \\"change\\",
                                                                                                                                 \\"_id\\": \\"4846\\",
                                                                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                 \\"type\\": \\"UPDATE\\"
@@ -5188,7 +5188,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"pathTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"4844\\",
                                                                                                                                         \\"v1\\": [
                                                                                                                                             \\"Properties\\",
@@ -5218,7 +5218,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"propertyTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"4845\\"
                                                                                                                                     },
                                                                                                                                     \\"outgoingNodeReferences\\": {
@@ -5231,7 +5231,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 \\"innerOperations\\": [
                                                                                                                                     {
                                                                                                                                         \\"nodeData\\": {
-                                                                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                                                                            \\"entityType\\": \\"change\\",
                                                                                                                                             \\"_id\\": \\"4843\\",
                                                                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                             \\"type\\": \\"UPDATE\\"
@@ -5243,7 +5243,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"pathTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"4841\\",
                                                                                                                                                     \\"v1\\": [
                                                                                                                                                         \\"Properties\\",
@@ -5275,7 +5275,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"propertyTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"4842\\"
                                                                                                                                                 },
                                                                                                                                                 \\"outgoingNodeReferences\\": {
@@ -5385,7 +5385,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"8241\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -5653,7 +5653,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8239\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -5663,7 +5663,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8240\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -5674,13 +5674,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"7727\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1322\\",
                                     \\"name\\": \\"InstanceC1063A87\\",
                                     \\"type\\": \\"Resource\\",
@@ -5694,7 +5694,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2661\\",
                                     \\"name\\": \\"InstanceC1063A87\\",
                                     \\"type\\": \\"Resource\\",
@@ -5712,7 +5712,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"8075\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -5724,7 +5724,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"8073\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -5738,7 +5738,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"8074\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -5751,7 +5751,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"7759\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -5763,7 +5763,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"7757\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -5779,7 +5779,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"7758\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -5792,7 +5792,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"7756\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -5804,7 +5804,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"7754\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -5822,7 +5822,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"7755\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -5835,7 +5835,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"7753\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -5847,7 +5847,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"7751\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -5867,7 +5867,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"7752\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -5923,7 +5923,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"8466\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -6049,7 +6049,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8464\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -6059,7 +6059,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8465\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -6070,13 +6070,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8243\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1368\\",
                                     \\"name\\": \\"WebAppDeploymentCustomResourceD7DB25D0\\",
                                     \\"type\\": \\"Resource\\",
@@ -6090,7 +6090,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2707\\",
                                     \\"name\\": \\"WebAppDeploymentCustomResourceD7DB25D0\\",
                                     \\"type\\": \\"Resource\\",
@@ -6108,7 +6108,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"8463\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -6120,7 +6120,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"8461\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -6134,7 +6134,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"8462\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -6147,7 +6147,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"8263\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -6159,7 +6159,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"8261\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -6175,7 +6175,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"8262\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -6188,7 +6188,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"8260\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -6200,7 +6200,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"8258\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -6218,7 +6218,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"8259\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -6231,7 +6231,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"8257\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -6243,7 +6243,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"8255\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -6263,7 +6263,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"8256\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -6301,7 +6301,7 @@ exports[`Matching big template 1`] = `
                                     },
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"8460\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -6313,7 +6313,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"8458\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -6329,7 +6329,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"8459\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -6342,7 +6342,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"8457\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -6354,7 +6354,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"8455\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -6372,7 +6372,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"8456\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -6385,7 +6385,7 @@ exports[`Matching big template 1`] = `
                                                         \\"innerOperations\\": [
                                                             {
                                                                 \\"nodeData\\": {
-                                                                    \\"_entityType\\": \\"change\\",
+                                                                    \\"entityType\\": \\"change\\",
                                                                     \\"_id\\": \\"8454\\",
                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                     \\"type\\": \\"UPDATE\\"
@@ -6397,7 +6397,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"pathTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"8452\\",
                                                                             \\"v1\\": [
                                                                                 \\"Properties\\",
@@ -6417,7 +6417,7 @@ exports[`Matching big template 1`] = `
                                                                     },
                                                                     \\"propertyTransition\\": {
                                                                         \\"nodeData\\": {
-                                                                            \\"_entityType\\": \\"transition\\",
+                                                                            \\"entityType\\": \\"transition\\",
                                                                             \\"_id\\": \\"8453\\"
                                                                         },
                                                                         \\"outgoingNodeReferences\\": {
@@ -6430,7 +6430,7 @@ exports[`Matching big template 1`] = `
                                                                     \\"innerOperations\\": [
                                                                         {
                                                                             \\"nodeData\\": {
-                                                                                \\"_entityType\\": \\"change\\",
+                                                                                \\"entityType\\": \\"change\\",
                                                                                 \\"_id\\": \\"8451\\",
                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                 \\"type\\": \\"UPDATE\\"
@@ -6442,7 +6442,7 @@ exports[`Matching big template 1`] = `
                                                                                 },
                                                                                 \\"pathTransition\\": {
                                                                                     \\"nodeData\\": {
-                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                        \\"entityType\\": \\"transition\\",
                                                                                         \\"_id\\": \\"8449\\",
                                                                                         \\"v1\\": [
                                                                                             \\"Properties\\",
@@ -6464,7 +6464,7 @@ exports[`Matching big template 1`] = `
                                                                                 },
                                                                                 \\"propertyTransition\\": {
                                                                                     \\"nodeData\\": {
-                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                        \\"entityType\\": \\"transition\\",
                                                                                         \\"_id\\": \\"8450\\"
                                                                                     },
                                                                                     \\"outgoingNodeReferences\\": {
@@ -6477,7 +6477,7 @@ exports[`Matching big template 1`] = `
                                                                                 \\"innerOperations\\": [
                                                                                     {
                                                                                         \\"nodeData\\": {
-                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                            \\"entityType\\": \\"change\\",
                                                                                             \\"_id\\": \\"8313\\",
                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                             \\"type\\": \\"UPDATE\\"
@@ -6489,7 +6489,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"pathTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"8311\\",
                                                                                                     \\"v1\\": [
                                                                                                         \\"Properties\\",
@@ -6513,7 +6513,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"propertyTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"8312\\"
                                                                                                 },
                                                                                                 \\"outgoingNodeReferences\\": {
@@ -6526,7 +6526,7 @@ exports[`Matching big template 1`] = `
                                                                                             \\"innerOperations\\": [
                                                                                                 {
                                                                                                     \\"nodeData\\": {
-                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                         \\"_id\\": \\"8310\\",
                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -6538,7 +6538,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"pathTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"8308\\",
                                                                                                                 \\"v1\\": [
                                                                                                                     \\"Properties\\",
@@ -6564,7 +6564,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"propertyTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"8309\\"
                                                                                                             },
                                                                                                             \\"outgoingNodeReferences\\": {
@@ -6577,7 +6577,7 @@ exports[`Matching big template 1`] = `
                                                                                                         \\"innerOperations\\": [
                                                                                                             {
                                                                                                                 \\"nodeData\\": {
-                                                                                                                    \\"_entityType\\": \\"change\\",
+                                                                                                                    \\"entityType\\": \\"change\\",
                                                                                                                     \\"_id\\": \\"8307\\",
                                                                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                     \\"type\\": \\"UPDATE\\"
@@ -6589,7 +6589,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"pathTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"8305\\",
                                                                                                                             \\"v1\\": [
                                                                                                                                 \\"Properties\\",
@@ -6617,7 +6617,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"propertyTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"8306\\"
                                                                                                                         },
                                                                                                                         \\"outgoingNodeReferences\\": {
@@ -6630,7 +6630,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     \\"innerOperations\\": [
                                                                                                                         {
                                                                                                                             \\"nodeData\\": {
-                                                                                                                                \\"_entityType\\": \\"change\\",
+                                                                                                                                \\"entityType\\": \\"change\\",
                                                                                                                                 \\"_id\\": \\"8304\\",
                                                                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                 \\"type\\": \\"UPDATE\\"
@@ -6642,7 +6642,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"pathTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"8302\\",
                                                                                                                                         \\"v1\\": [
                                                                                                                                             \\"Properties\\",
@@ -6672,7 +6672,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"propertyTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"8303\\"
                                                                                                                                     },
                                                                                                                                     \\"outgoingNodeReferences\\": {
@@ -6685,7 +6685,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 \\"innerOperations\\": [
                                                                                                                                     {
                                                                                                                                         \\"nodeData\\": {
-                                                                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                                                                            \\"entityType\\": \\"change\\",
                                                                                                                                             \\"_id\\": \\"8301\\",
                                                                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                             \\"type\\": \\"UPDATE\\"
@@ -6697,7 +6697,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"pathTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"8299\\",
                                                                                                                                                     \\"v1\\": [
                                                                                                                                                         \\"Properties\\",
@@ -6729,7 +6729,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"propertyTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"8300\\"
                                                                                                                                                 },
                                                                                                                                                 \\"outgoingNodeReferences\\": {
@@ -6742,7 +6742,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             \\"innerOperations\\": [
                                                                                                                                                 {
                                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                                                                         \\"_id\\": \\"8298\\",
                                                                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -6754,7 +6754,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"pathTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"8296\\",
                                                                                                                                                                 \\"v1\\": [
                                                                                                                                                                     \\"Properties\\",
@@ -6788,7 +6788,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"propertyTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"8297\\"
                                                                                                                                                             },
                                                                                                                                                             \\"outgoingNodeReferences\\": {
@@ -6853,7 +6853,7 @@ exports[`Matching big template 1`] = `
                                                                                     },
                                                                                     {
                                                                                         \\"nodeData\\": {
-                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                            \\"entityType\\": \\"change\\",
                                                                                             \\"_id\\": \\"8448\\",
                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                             \\"type\\": \\"UPDATE\\"
@@ -6865,7 +6865,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"pathTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"8446\\",
                                                                                                     \\"v1\\": [
                                                                                                         \\"Properties\\",
@@ -6889,7 +6889,7 @@ exports[`Matching big template 1`] = `
                                                                                             },
                                                                                             \\"propertyTransition\\": {
                                                                                                 \\"nodeData\\": {
-                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                     \\"_id\\": \\"8447\\"
                                                                                                 },
                                                                                                 \\"outgoingNodeReferences\\": {
@@ -6902,7 +6902,7 @@ exports[`Matching big template 1`] = `
                                                                                             \\"innerOperations\\": [
                                                                                                 {
                                                                                                     \\"nodeData\\": {
-                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                         \\"_id\\": \\"8445\\",
                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -6914,7 +6914,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"pathTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"8443\\",
                                                                                                                 \\"v1\\": [
                                                                                                                     \\"Properties\\",
@@ -6940,7 +6940,7 @@ exports[`Matching big template 1`] = `
                                                                                                         },
                                                                                                         \\"propertyTransition\\": {
                                                                                                             \\"nodeData\\": {
-                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                 \\"_id\\": \\"8444\\"
                                                                                                             },
                                                                                                             \\"outgoingNodeReferences\\": {
@@ -6953,7 +6953,7 @@ exports[`Matching big template 1`] = `
                                                                                                         \\"innerOperations\\": [
                                                                                                             {
                                                                                                                 \\"nodeData\\": {
-                                                                                                                    \\"_entityType\\": \\"change\\",
+                                                                                                                    \\"entityType\\": \\"change\\",
                                                                                                                     \\"_id\\": \\"8442\\",
                                                                                                                     \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                     \\"type\\": \\"UPDATE\\"
@@ -6965,7 +6965,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"pathTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"8440\\",
                                                                                                                             \\"v1\\": [
                                                                                                                                 \\"Properties\\",
@@ -6993,7 +6993,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     },
                                                                                                                     \\"propertyTransition\\": {
                                                                                                                         \\"nodeData\\": {
-                                                                                                                            \\"_entityType\\": \\"transition\\",
+                                                                                                                            \\"entityType\\": \\"transition\\",
                                                                                                                             \\"_id\\": \\"8441\\"
                                                                                                                         },
                                                                                                                         \\"outgoingNodeReferences\\": {
@@ -7006,7 +7006,7 @@ exports[`Matching big template 1`] = `
                                                                                                                     \\"innerOperations\\": [
                                                                                                                         {
                                                                                                                             \\"nodeData\\": {
-                                                                                                                                \\"_entityType\\": \\"change\\",
+                                                                                                                                \\"entityType\\": \\"change\\",
                                                                                                                                 \\"_id\\": \\"8439\\",
                                                                                                                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                 \\"type\\": \\"UPDATE\\"
@@ -7018,7 +7018,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"pathTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"8437\\",
                                                                                                                                         \\"v1\\": [
                                                                                                                                             \\"Properties\\",
@@ -7048,7 +7048,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 },
                                                                                                                                 \\"propertyTransition\\": {
                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                        \\"_entityType\\": \\"transition\\",
+                                                                                                                                        \\"entityType\\": \\"transition\\",
                                                                                                                                         \\"_id\\": \\"8438\\"
                                                                                                                                     },
                                                                                                                                     \\"outgoingNodeReferences\\": {
@@ -7061,7 +7061,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                 \\"innerOperations\\": [
                                                                                                                                     {
                                                                                                                                         \\"nodeData\\": {
-                                                                                                                                            \\"_entityType\\": \\"change\\",
+                                                                                                                                            \\"entityType\\": \\"change\\",
                                                                                                                                             \\"_id\\": \\"8436\\",
                                                                                                                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                             \\"type\\": \\"UPDATE\\"
@@ -7073,7 +7073,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"pathTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"8434\\",
                                                                                                                                                     \\"v1\\": [
                                                                                                                                                         \\"Properties\\",
@@ -7105,7 +7105,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             },
                                                                                                                                             \\"propertyTransition\\": {
                                                                                                                                                 \\"nodeData\\": {
-                                                                                                                                                    \\"_entityType\\": \\"transition\\",
+                                                                                                                                                    \\"entityType\\": \\"transition\\",
                                                                                                                                                     \\"_id\\": \\"8435\\"
                                                                                                                                                 },
                                                                                                                                                 \\"outgoingNodeReferences\\": {
@@ -7118,7 +7118,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                             \\"innerOperations\\": [
                                                                                                                                                 {
                                                                                                                                                     \\"nodeData\\": {
-                                                                                                                                                        \\"_entityType\\": \\"change\\",
+                                                                                                                                                        \\"entityType\\": \\"change\\",
                                                                                                                                                         \\"_id\\": \\"8433\\",
                                                                                                                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                                                                                                                         \\"type\\": \\"UPDATE\\"
@@ -7130,7 +7130,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"pathTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"8431\\",
                                                                                                                                                                 \\"v1\\": [
                                                                                                                                                                     \\"Properties\\",
@@ -7164,7 +7164,7 @@ exports[`Matching big template 1`] = `
                                                                                                                                                         },
                                                                                                                                                         \\"propertyTransition\\": {
                                                                                                                                                             \\"nodeData\\": {
-                                                                                                                                                                \\"_entityType\\": \\"transition\\",
+                                                                                                                                                                \\"entityType\\": \\"transition\\",
                                                                                                                                                                 \\"_id\\": \\"8432\\"
                                                                                                                                                             },
                                                                                                                                                             \\"outgoingNodeReferences\\": {
@@ -7283,7 +7283,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"8568\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7291,7 +7291,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"1702\\",
                                 \\"name\\": \\"S3GatewayGameAppDeployment45A40F1C4b3c56c977a48268e4d338b071d20578\\",
                                 \\"type\\": \\"Resource\\",
@@ -7321,7 +7321,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2913\\",
                                 \\"name\\": \\"S3GatewayGameAppDeployment45A40F1C1ea3f370273feac6dc79badcdb1c5090\\",
                                 \\"type\\": \\"Resource\\",
@@ -7352,7 +7352,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8482\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7369,7 +7369,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"8581\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -7405,7 +7405,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8579\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -7415,7 +7415,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8580\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7426,13 +7426,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"8569\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"1713\\",
                                     \\"name\\": \\"S3GatewayGameAppDeploymentStageprod501ACE37\\",
                                     \\"type\\": \\"Resource\\",
@@ -7446,7 +7446,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2924\\",
                                     \\"name\\": \\"S3GatewayGameAppDeploymentStageprod501ACE37\\",
                                     \\"type\\": \\"Resource\\",
@@ -7464,7 +7464,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"8578\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -7476,7 +7476,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"8576\\",
                                         \\"v1\\": [
                                             \\"Properties\\"
@@ -7490,7 +7490,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"8577\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -7503,7 +7503,7 @@ exports[`Matching big template 1`] = `
                                 \\"innerOperations\\": [
                                     {
                                         \\"nodeData\\": {
-                                            \\"_entityType\\": \\"change\\",
+                                            \\"entityType\\": \\"change\\",
                                             \\"_id\\": \\"8575\\",
                                             \\"propertyOperationType\\": \\"UPDATE\\",
                                             \\"type\\": \\"UPDATE\\"
@@ -7515,7 +7515,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"pathTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"8573\\",
                                                     \\"v1\\": [
                                                         \\"Properties\\",
@@ -7531,7 +7531,7 @@ exports[`Matching big template 1`] = `
                                             },
                                             \\"propertyTransition\\": {
                                                 \\"nodeData\\": {
-                                                    \\"_entityType\\": \\"transition\\",
+                                                    \\"entityType\\": \\"transition\\",
                                                     \\"_id\\": \\"8574\\"
                                                 },
                                                 \\"outgoingNodeReferences\\": {
@@ -7544,7 +7544,7 @@ exports[`Matching big template 1`] = `
                                             \\"innerOperations\\": [
                                                 {
                                                     \\"nodeData\\": {
-                                                        \\"_entityType\\": \\"change\\",
+                                                        \\"entityType\\": \\"change\\",
                                                         \\"_id\\": \\"8572\\",
                                                         \\"propertyOperationType\\": \\"UPDATE\\",
                                                         \\"type\\": \\"UPDATE\\"
@@ -7556,7 +7556,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"pathTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"8570\\",
                                                                 \\"v1\\": [
                                                                     \\"Properties\\",
@@ -7574,7 +7574,7 @@ exports[`Matching big template 1`] = `
                                                         },
                                                         \\"propertyTransition\\": {
                                                             \\"nodeData\\": {
-                                                                \\"_entityType\\": \\"transition\\",
+                                                                \\"entityType\\": \\"transition\\",
                                                                 \\"_id\\": \\"8571\\"
                                                             },
                                                             \\"outgoingNodeReferences\\": {
@@ -7621,7 +7621,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9829\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7629,7 +7629,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2007\\",
                                 \\"name\\": \\"AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3VersionKeyE9526174\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7646,7 +7646,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3433\\",
                                 \\"name\\": \\"AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7664,7 +7664,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9626\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7681,7 +7681,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9830\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7689,7 +7689,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2011\\",
                                 \\"name\\": \\"AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3ArtifactHash1CB34D4B\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7706,7 +7706,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3437\\",
                                 \\"name\\": \\"AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fArtifactHashE5AC1E7E\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7724,7 +7724,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9675\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7741,7 +7741,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9831\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7749,7 +7749,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2019\\",
                                 \\"name\\": \\"AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3VersionKey484CA5B8\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7766,7 +7766,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3445\\",
                                 \\"name\\": \\"AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7784,7 +7784,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9773\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7801,7 +7801,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9832\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7809,7 +7809,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2023\\",
                                 \\"name\\": \\"AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caArtifactHash985C4613\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7826,7 +7826,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3449\\",
                                 \\"name\\": \\"AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7ArtifactHash6C4D52FA\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7844,7 +7844,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9822\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7861,7 +7861,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9833\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7869,7 +7869,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2003\\",
                                 \\"name\\": \\"AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7886,7 +7886,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3429\\",
                                 \\"name\\": \\"AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7904,7 +7904,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9577\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7921,7 +7921,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9834\\",
                     \\"type\\": \\"RENAME\\"
                 },
@@ -7929,7 +7929,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"old\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"2015\\",
                                 \\"name\\": \\"AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3Bucket5BA77413\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7946,7 +7946,7 @@ exports[`Matching big template 1`] = `
                         },
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3441\\",
                                 \\"name\\": \\"AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3BucketA30C151C\\",
                                 \\"type\\": \\"Parameter\\",
@@ -7964,7 +7964,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9724\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -7981,7 +7981,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9632\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -7993,7 +7993,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9630\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8003,7 +8003,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9631\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8016,7 +8016,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"9629\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8028,7 +8028,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9627\\",
                                         \\"v1\\": [
                                             \\"Description\\"
@@ -8042,7 +8042,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9628\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8071,7 +8071,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9681\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8083,7 +8083,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9679\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8093,7 +8093,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9680\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8106,7 +8106,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"9678\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8118,7 +8118,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9676\\",
                                         \\"v1\\": [
                                             \\"Description\\"
@@ -8132,7 +8132,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9677\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8161,7 +8161,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9779\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8173,7 +8173,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9777\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8183,7 +8183,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9778\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8196,7 +8196,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"9776\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8208,7 +8208,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9774\\",
                                         \\"v1\\": [
                                             \\"Description\\"
@@ -8222,7 +8222,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9775\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8251,7 +8251,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9828\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8263,7 +8263,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9826\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8273,7 +8273,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9827\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8286,7 +8286,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"9825\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8298,7 +8298,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9823\\",
                                         \\"v1\\": [
                                             \\"Description\\"
@@ -8312,7 +8312,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9824\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8341,7 +8341,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9583\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8353,7 +8353,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9581\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8363,7 +8363,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9582\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8376,7 +8376,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"9580\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8388,7 +8388,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9578\\",
                                         \\"v1\\": [
                                             \\"Description\\"
@@ -8402,7 +8402,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9579\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8431,7 +8431,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"9730\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8443,7 +8443,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9728\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8453,7 +8453,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"9729\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8466,7 +8466,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"9727\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8478,7 +8478,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9725\\",
                                         \\"v1\\": [
                                             \\"Description\\"
@@ -8492,7 +8492,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"9726\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8521,7 +8521,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17871\\",
                     \\"type\\": \\"INSERT\\"
                 },
@@ -8529,7 +8529,7 @@ exports[`Matching big template 1`] = `
                     \\"exposesValues\\": {
                         \\"new\\": {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"component\\",
+                                \\"entityType\\": \\"component\\",
                                 \\"_id\\": \\"3720\\",
                                 \\"name\\": \\"Default\\",
                                 \\"type\\": \\"CDK Construct\\"
@@ -8545,7 +8545,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17870\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8560,7 +8560,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"14737\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8576,7 +8576,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14735\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8586,7 +8586,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14736\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8597,13 +8597,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14731\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2287\\",
                                     \\"name\\": \\"ApiPermission.Test.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -8616,7 +8616,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3677\\",
                                     \\"name\\": \\"ApiPermission.Test.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -8633,7 +8633,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"14734\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8645,7 +8645,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14732\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -8659,7 +8659,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14733\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8688,7 +8688,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"14664\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8704,7 +8704,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14662\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8714,7 +8714,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14663\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8725,13 +8725,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14658\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2283\\",
                                     \\"name\\": \\"ApiPermission.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -8744,7 +8744,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3673\\",
                                     \\"name\\": \\"ApiPermission.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -8761,7 +8761,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"14661\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8773,7 +8773,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14659\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -8787,7 +8787,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14660\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8816,7 +8816,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"13893\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8832,7 +8832,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13891\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8842,7 +8842,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13892\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8853,13 +8853,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13887\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2267\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -8872,7 +8872,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3637\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -8889,7 +8889,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"13890\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -8901,7 +8901,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13888\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -8915,7 +8915,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13889\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -8944,7 +8944,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"12583\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -8960,7 +8960,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12581\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -8970,7 +8970,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12582\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -8981,13 +8981,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12577\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2239\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9000,7 +9000,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3629\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9017,7 +9017,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"12580\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9029,7 +9029,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"12578\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9043,7 +9043,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"12579\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9072,7 +9072,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"13711\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9088,7 +9088,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13709\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9098,7 +9098,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13710\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9109,13 +9109,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13705\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2263\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9128,7 +9128,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3653\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9145,7 +9145,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"13708\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9157,7 +9157,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13706\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9171,7 +9171,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13707\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9200,7 +9200,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"14344\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9216,7 +9216,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14342\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9226,7 +9226,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14343\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9237,13 +9237,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14338\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2275\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9256,7 +9256,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3665\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9273,7 +9273,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"14341\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9285,7 +9285,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14339\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9299,7 +9299,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14340\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9328,7 +9328,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"10975\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9344,7 +9344,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10973\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9354,7 +9354,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10974\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9365,13 +9365,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10969\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2203\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9384,7 +9384,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3605\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9401,7 +9401,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"10972\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9413,7 +9413,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10970\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9427,7 +9427,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10971\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9456,7 +9456,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"14133\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9472,7 +9472,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14131\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9482,7 +9482,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14132\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9493,13 +9493,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14127\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2271\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9512,7 +9512,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3661\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9529,7 +9529,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"14130\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9541,7 +9541,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14128\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9555,7 +9555,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14129\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9584,7 +9584,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"14912\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9600,7 +9600,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14910\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9610,7 +9610,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14911\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9621,13 +9621,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14906\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2291\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9640,7 +9640,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3681\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9657,7 +9657,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"14909\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9669,7 +9669,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14907\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9683,7 +9683,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14908\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9712,7 +9712,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"13216\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9728,7 +9728,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13214\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9738,7 +9738,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13215\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9749,13 +9749,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13210\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2251\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9768,7 +9768,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3641\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9785,7 +9785,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"13213\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9797,7 +9797,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13211\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9811,7 +9811,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13212\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9840,7 +9840,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15334\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9856,7 +9856,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15332\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9866,7 +9866,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15333\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -9877,13 +9877,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15328\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2299\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9896,7 +9896,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3689\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -9913,7 +9913,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15331\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -9925,7 +9925,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15329\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -9939,7 +9939,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15330\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -9968,7 +9968,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"10553\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -9984,7 +9984,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10551\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -9994,7 +9994,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10552\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10005,13 +10005,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10547\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2195\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10024,7 +10024,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3597\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10041,7 +10041,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"10550\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10053,7 +10053,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10548\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10067,7 +10067,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10549\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10096,7 +10096,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"11651\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10112,7 +10112,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11649\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10122,7 +10122,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11650\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10133,13 +10133,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11645\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2219\\",
                                     \\"name\\": \\"Default\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10152,7 +10152,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3621\\",
                                     \\"name\\": \\"Default\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10169,7 +10169,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"11648\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10181,7 +10181,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11646\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10195,7 +10195,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11647\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10224,7 +10224,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"14555\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10240,7 +10240,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14553\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10250,7 +10250,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14554\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10261,13 +10261,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"14549\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2279\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10280,7 +10280,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3669\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10297,7 +10297,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"14552\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10309,7 +10309,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14550\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10323,7 +10323,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"14551\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10352,7 +10352,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16783\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10368,7 +10368,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16781\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10378,7 +10378,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16782\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10389,13 +10389,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16777\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2390\\",
                                     \\"name\\": \\"DefaultPolicy\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10408,7 +10408,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3783\\",
                                     \\"name\\": \\"DefaultPolicy\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10425,7 +10425,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16780\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10437,7 +10437,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16778\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10451,7 +10451,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16779\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10480,7 +10480,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17160\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10496,7 +10496,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17158\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10506,7 +10506,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17159\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10517,13 +10517,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17154\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2416\\",
                                     \\"name\\": \\"DeploymentStage.prod\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10536,7 +10536,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3809\\",
                                     \\"name\\": \\"DeploymentStage.prod\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10553,7 +10553,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17157\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10565,7 +10565,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17155\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10579,7 +10579,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17156\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10608,7 +10608,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17488\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10624,7 +10624,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17486\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10634,7 +10634,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17487\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10645,13 +10645,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17482\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2435\\",
                                     \\"name\\": \\"GET\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10664,7 +10664,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3828\\",
                                     \\"name\\": \\"GET\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10681,7 +10681,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17485\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10693,7 +10693,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17483\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10707,7 +10707,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17484\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10736,7 +10736,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"13500\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10752,7 +10752,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13498\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10762,7 +10762,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13499\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10773,13 +10773,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13494\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2259\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10792,7 +10792,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3649\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10809,7 +10809,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"13497\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10821,7 +10821,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13495\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10835,7 +10835,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13496\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10864,7 +10864,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16093\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -10880,7 +10880,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16091\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -10890,7 +10890,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16092\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -10901,13 +10901,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16087\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2345\\",
                                     \\"name\\": \\"DefaultPolicy\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10920,7 +10920,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3753\\",
                                     \\"name\\": \\"DefaultPolicy\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -10937,7 +10937,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16090\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -10949,7 +10949,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16088\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -10963,7 +10963,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16089\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -10992,7 +10992,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17409\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11008,7 +11008,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17407\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11018,7 +11018,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17408\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11029,13 +11029,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17403\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2430\\",
                                     \\"name\\": \\"{proxy+}\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11048,7 +11048,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3823\\",
                                     \\"name\\": \\"{proxy+}\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11065,7 +11065,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17406\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11077,7 +11077,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17404\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11091,7 +11091,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17405\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11120,7 +11120,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"12372\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11136,7 +11136,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12370\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11146,7 +11146,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12371\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11157,13 +11157,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12366\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2235\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11176,7 +11176,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3625\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11193,7 +11193,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"12369\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11205,7 +11205,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"12367\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11219,7 +11219,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"12368\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11248,7 +11248,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17634\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11264,7 +11264,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17632\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11274,7 +11274,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17633\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11285,13 +11285,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17628\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2445\\",
                                     \\"name\\": \\"ANY\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11304,7 +11304,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3838\\",
                                     \\"name\\": \\"ANY\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11321,7 +11321,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17631\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11333,7 +11333,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17629\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11347,7 +11347,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17630\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11376,7 +11376,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17014\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11392,7 +11392,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17012\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11402,7 +11402,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17013\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11413,13 +11413,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17008\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2405\\",
                                     \\"name\\": \\"CloudWatchRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11432,7 +11432,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3798\\",
                                     \\"name\\": \\"CloudWatchRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11449,7 +11449,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17011\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11461,7 +11461,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17009\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11475,7 +11475,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17010\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11504,7 +11504,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16257\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11520,7 +11520,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16255\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11530,7 +11530,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16256\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11541,13 +11541,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16251\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2357\\",
                                     \\"name\\": \\"CustomResource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11560,7 +11560,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3765\\",
                                     \\"name\\": \\"CustomResource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11577,7 +11577,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16254\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11589,7 +11589,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16252\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11603,7 +11603,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16253\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11632,7 +11632,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17792\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11648,7 +11648,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17790\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11658,7 +11658,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17791\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11669,13 +11669,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17786\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2457\\",
                                     \\"name\\": \\"DefaultPolicy\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11688,7 +11688,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3850\\",
                                     \\"name\\": \\"DefaultPolicy\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11705,7 +11705,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17789\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11717,7 +11717,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17787\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11731,7 +11731,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17788\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11760,7 +11760,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"10764\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11776,7 +11776,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10762\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11786,7 +11786,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10763\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11797,13 +11797,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10758\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2199\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11816,7 +11816,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3601\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11833,7 +11833,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"10761\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11845,7 +11845,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10759\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11859,7 +11859,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10760\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -11888,7 +11888,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15874\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -11904,7 +11904,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15872\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -11914,7 +11914,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15873\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -11925,13 +11925,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15868\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2331\\",
                                     \\"name\\": \\"InstanceSecurityGroup\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11944,7 +11944,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3739\\",
                                     \\"name\\": \\"InstanceSecurityGroup\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -11961,7 +11961,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15871\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -11973,7 +11973,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15869\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -11987,7 +11987,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15870\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12016,7 +12016,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17233\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12032,7 +12032,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17231\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12042,7 +12042,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17232\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12053,13 +12053,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17227\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2421\\",
                                     \\"name\\": \\"GET\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12072,7 +12072,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3814\\",
                                     \\"name\\": \\"GET\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12089,7 +12089,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17230\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12101,7 +12101,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17228\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12115,7 +12115,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17229\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12144,7 +12144,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17561\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12160,7 +12160,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17559\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12170,7 +12170,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17560\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12181,13 +12181,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17555\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2440\\",
                                     \\"name\\": \\"api\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12200,7 +12200,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3833\\",
                                     \\"name\\": \\"api\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12217,7 +12217,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17558\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12229,7 +12229,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17556\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12243,7 +12243,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17557\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12272,7 +12272,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17087\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12288,7 +12288,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17085\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12298,7 +12298,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17086\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12309,13 +12309,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17081\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2411\\",
                                     \\"name\\": \\"Deployment\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12328,7 +12328,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3804\\",
                                     \\"name\\": \\"Deployment\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12345,7 +12345,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17084\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12357,7 +12357,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17082\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12371,7 +12371,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17083\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12400,7 +12400,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15123\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12416,7 +12416,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15121\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12426,7 +12426,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15122\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12437,13 +12437,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15117\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2295\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12456,7 +12456,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3685\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12473,7 +12473,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15120\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12485,7 +12485,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15118\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12499,7 +12499,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15119\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12528,7 +12528,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"13361\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12544,7 +12544,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13359\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12554,7 +12554,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13360\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12565,13 +12565,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13355\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2255\\",
                                     \\"name\\": \\"Account\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12584,7 +12584,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3645\\",
                                     \\"name\\": \\"Account\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12601,7 +12601,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"13358\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12613,7 +12613,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13356\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12627,7 +12627,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13357\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12656,7 +12656,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17336\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12672,7 +12672,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17334\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12682,7 +12682,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17335\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12693,13 +12693,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17330\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2424\\",
                                     \\"name\\": \\"Default\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12712,7 +12712,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3817\\",
                                     \\"name\\": \\"Default\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12729,7 +12729,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17333\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12741,7 +12741,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17331\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12755,7 +12755,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17332\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12784,7 +12784,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"11162\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12800,7 +12800,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11160\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12810,7 +12810,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11161\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12821,13 +12821,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11156\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2207\\",
                                     \\"name\\": \\"InstanceProfile\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12840,7 +12840,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3609\\",
                                     \\"name\\": \\"InstanceProfile\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12857,7 +12857,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"11159\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12869,7 +12869,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11157\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -12883,7 +12883,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11158\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -12912,7 +12912,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16625\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -12928,7 +12928,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16623\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -12938,7 +12938,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16624\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -12949,13 +12949,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16619\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2381\\",
                                     \\"name\\": \\"ServiceRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12968,7 +12968,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3774\\",
                                     \\"name\\": \\"ServiceRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -12985,7 +12985,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16622\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -12997,7 +12997,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16620\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13011,7 +13011,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16621\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13040,7 +13040,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"10318\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13056,7 +13056,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10316\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13066,7 +13066,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10317\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13077,13 +13077,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10312\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2183\\",
                                     \\"name\\": \\"Default\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13096,7 +13096,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3593\\",
                                     \\"name\\": \\"Default\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13113,7 +13113,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"10315\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13125,7 +13125,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10313\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13139,7 +13139,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10314\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13168,7 +13168,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"11470\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13184,7 +13184,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11468\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13194,7 +13194,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11469\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13205,13 +13205,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11464\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2215\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13224,7 +13224,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3617\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13241,7 +13241,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"11467\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13253,7 +13253,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11465\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13267,7 +13267,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11466\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13296,7 +13296,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"12794\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13312,7 +13312,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12792\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13322,7 +13322,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12793\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13333,13 +13333,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"12788\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2243\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13352,7 +13352,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3633\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13369,7 +13369,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"12791\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13381,7 +13381,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"12789\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13395,7 +13395,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"12790\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13424,7 +13424,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16020\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13440,7 +13440,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16018\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13450,7 +13450,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16019\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13461,13 +13461,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16014\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2340\\",
                                     \\"name\\": \\"InstanceRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13480,7 +13480,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3748\\",
                                     \\"name\\": \\"InstanceRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13497,7 +13497,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16017\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13509,7 +13509,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16015\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13523,7 +13523,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16016\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13552,7 +13552,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"10040\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13568,7 +13568,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10038\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13578,7 +13578,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10039\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13589,13 +13589,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10034\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2175\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13608,7 +13608,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3585\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13625,7 +13625,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"10037\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13637,7 +13637,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10035\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13651,7 +13651,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10036\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13680,7 +13680,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"11259\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13696,7 +13696,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11257\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13706,7 +13706,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11258\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13717,13 +13717,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"11253\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2211\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13736,7 +13736,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3613\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13753,7 +13753,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"11256\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13765,7 +13765,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11254\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13779,7 +13779,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"11255\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13808,7 +13808,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16868\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13824,7 +13824,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16866\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13834,7 +13834,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16867\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13845,13 +13845,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16862\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2396\\",
                                     \\"name\\": \\"GameApp\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13864,7 +13864,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3789\\",
                                     \\"name\\": \\"GameApp\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13881,7 +13881,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16865\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -13893,7 +13893,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16863\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -13907,7 +13907,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16864\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -13936,7 +13936,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"17707\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -13952,7 +13952,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17705\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -13962,7 +13962,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17706\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -13973,13 +13973,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"17701\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2452\\",
                                     \\"name\\": \\"S3IntegrationRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -13992,7 +13992,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3845\\",
                                     \\"name\\": \\"S3IntegrationRole\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14009,7 +14009,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"17704\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14021,7 +14021,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17702\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14035,7 +14035,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"17703\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14064,7 +14064,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16330\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14080,7 +14080,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16328\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14090,7 +14090,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16329\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14101,13 +14101,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16324\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2360\\",
                                     \\"name\\": \\"WebAppDeployment\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14120,7 +14120,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3768\\",
                                     \\"name\\": \\"WebAppDeployment\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14137,7 +14137,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16327\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14149,7 +14149,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16325\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14163,7 +14163,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16326\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14192,7 +14192,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15662\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14208,7 +14208,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15660\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14218,7 +14218,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15661\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14229,13 +14229,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15656\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2316\\",
                                     \\"name\\": \\"KeyPair\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14248,7 +14248,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3730\\",
                                     \\"name\\": \\"KeyPair\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14265,7 +14265,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15659\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14277,7 +14277,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15657\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14291,7 +14291,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15658\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14320,7 +14320,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16184\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14336,7 +14336,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16182\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14346,7 +14346,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16183\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14357,13 +14357,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16178\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2352\\",
                                     \\"name\\": \\"WebAppBucket\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14376,7 +14376,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3760\\",
                                     \\"name\\": \\"WebAppBucket\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14393,7 +14393,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16181\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14405,7 +14405,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16179\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14419,7 +14419,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16180\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14448,7 +14448,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16704\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14464,7 +14464,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16702\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14474,7 +14474,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16703\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14485,13 +14485,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16698\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2384\\",
                                     \\"name\\": \\"WebAppLambda\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14504,7 +14504,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3777\\",
                                     \\"name\\": \\"WebAppLambda\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14521,7 +14521,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16701\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14533,7 +14533,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16699\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14547,7 +14547,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16700\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14576,7 +14576,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15521\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14592,7 +14592,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15519\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14602,7 +14602,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15520\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14613,13 +14613,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15515\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2307\\",
                                     \\"name\\": \\"NVidiaUser\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14632,7 +14632,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3717\\",
                                     \\"name\\": \\"NVidiaUser\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14649,7 +14649,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15518\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14661,7 +14661,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15516\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14675,7 +14675,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15517\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14704,7 +14704,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"10245\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14720,7 +14720,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10243\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14730,7 +14730,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10244\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14741,13 +14741,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"10239\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2179\\",
                                     \\"name\\": \\"AccessKey\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14760,7 +14760,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3589\\",
                                     \\"name\\": \\"AccessKey\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14777,7 +14777,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"10242\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14789,7 +14789,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10240\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14803,7 +14803,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"10241\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14832,7 +14832,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"16941\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14848,7 +14848,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16939\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14858,7 +14858,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16940\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14869,13 +14869,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"16935\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2399\\",
                                     \\"name\\": \\"S3Gateway\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14888,7 +14888,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3792\\",
                                     \\"name\\": \\"S3Gateway\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -14905,7 +14905,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"16938\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -14917,7 +14917,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16936\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -14931,7 +14931,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"16937\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -14960,7 +14960,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15947\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -14976,7 +14976,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15945\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -14986,7 +14986,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15946\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -14997,13 +14997,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15941\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2334\\",
                                     \\"name\\": \\"Instance\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -15016,7 +15016,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3742\\",
                                     \\"name\\": \\"Instance\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -15033,7 +15033,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15944\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -15045,7 +15045,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15942\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -15059,7 +15059,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15943\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -15088,7 +15088,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"15735\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -15104,7 +15104,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15733\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -15114,7 +15114,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15734\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -15125,13 +15125,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"15729\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2319\\",
                                     \\"name\\": \\"GameKey\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -15144,7 +15144,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3733\\",
                                     \\"name\\": \\"GameKey\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -15161,7 +15161,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"15732\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -15173,7 +15173,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15730\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -15187,7 +15187,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"15731\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -15216,7 +15216,7 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"change\\",
+                    \\"entityType\\": \\"change\\",
                     \\"_id\\": \\"13034\\",
                     \\"propertyOperationType\\": \\"UPDATE\\",
                     \\"type\\": \\"UPDATE\\"
@@ -15232,7 +15232,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"pathTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13032\\",
                             \\"v1\\": [],
                             \\"v2\\": \\"[dup-ref]v2\\"
@@ -15242,7 +15242,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"propertyTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13033\\"
                         },
                         \\"outgoingNodeReferences\\": {
@@ -15253,13 +15253,13 @@ exports[`Matching big template 1`] = `
                     },
                     \\"componentTransition\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"transition\\",
+                            \\"entityType\\": \\"transition\\",
                             \\"_id\\": \\"13028\\"
                         },
                         \\"outgoingNodeReferences\\": {
                             \\"v1\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"2247\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -15272,7 +15272,7 @@ exports[`Matching big template 1`] = `
                             },
                             \\"v2\\": {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"component\\",
+                                    \\"entityType\\": \\"component\\",
                                     \\"_id\\": \\"3657\\",
                                     \\"name\\": \\"Resource\\",
                                     \\"type\\": \\"CDK Construct\\"
@@ -15289,7 +15289,7 @@ exports[`Matching big template 1`] = `
                     \\"innerOperations\\": [
                         {
                             \\"nodeData\\": {
-                                \\"_entityType\\": \\"change\\",
+                                \\"entityType\\": \\"change\\",
                                 \\"_id\\": \\"13031\\",
                                 \\"propertyOperationType\\": \\"UPDATE\\",
                                 \\"type\\": \\"UPDATE\\"
@@ -15301,7 +15301,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"pathTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13029\\",
                                         \\"v1\\": [
                                             \\"path\\"
@@ -15315,7 +15315,7 @@ exports[`Matching big template 1`] = `
                                 },
                                 \\"propertyTransition\\": {
                                     \\"nodeData\\": {
-                                        \\"_entityType\\": \\"transition\\",
+                                        \\"entityType\\": \\"transition\\",
                                         \\"_id\\": \\"13030\\"
                                     },
                                     \\"outgoingNodeReferences\\": {
@@ -15346,13 +15346,13 @@ exports[`Matching big template 1`] = `
         \\"componentTransitions\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"3881\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1072\\",
                             \\"name\\": \\"NVidiaUser1BAF4BFB\\",
                             \\"type\\": \\"Resource\\",
@@ -15385,7 +15385,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2482\\",
                             \\"name\\": \\"NVidiaUser1BAF4BFB\\",
                             \\"type\\": \\"Resource\\",
@@ -15421,13 +15421,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"3920\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1080\\",
                             \\"name\\": \\"AccessKey\\",
                             \\"type\\": \\"Resource\\",
@@ -15449,7 +15449,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2490\\",
                             \\"name\\": \\"AccessKey\\",
                             \\"type\\": \\"Resource\\",
@@ -15474,13 +15474,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"3921\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1093\\",
                             \\"name\\": \\"GameKeyKeyPairF8B1B0F0\\",
                             \\"type\\": \\"Resource\\",
@@ -15508,7 +15508,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2503\\",
                             \\"name\\": \\"GameKeyKeyPairF8B1B0F0\\",
                             \\"type\\": \\"Resource\\",
@@ -15539,13 +15539,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"3936\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1125\\",
                             \\"name\\": \\"KeyPairProviderCustomResourceProviderRoleA32FD897\\",
                             \\"type\\": \\"Resource\\",
@@ -15603,7 +15603,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3211\\",
                             \\"name\\": \\"KeyPairProviderCustomResourceProviderRoleA32FD897\\",
                             \\"type\\": \\"Resource\\",
@@ -15664,13 +15664,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4023\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1391\\",
                             \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                             \\"type\\": \\"Resource\\",
@@ -15715,7 +15715,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3273\\",
                             \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                             \\"type\\": \\"Resource\\",
@@ -15763,13 +15763,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4064\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1519\\",
                             \\"name\\": \\"WebAppLambdaServiceRoleB3C5DDDA\\",
                             \\"type\\": \\"Resource\\",
@@ -15814,7 +15814,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2730\\",
                             \\"name\\": \\"WebAppLambdaServiceRoleB3C5DDDA\\",
                             \\"type\\": \\"Resource\\",
@@ -15862,13 +15862,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4110\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1675\\",
                             \\"name\\": \\"S3GatewayGameAppCloudWatchRole3E18F736\\",
                             \\"type\\": \\"Resource\\",
@@ -15913,7 +15913,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2886\\",
                             \\"name\\": \\"S3GatewayGameAppCloudWatchRole3E18F736\\",
                             \\"type\\": \\"Resource\\",
@@ -15961,13 +15961,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4156\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1935\\",
                             \\"name\\": \\"S3IntegrationRoleF31D2F62\\",
                             \\"type\\": \\"Resource\\",
@@ -15998,7 +15998,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3146\\",
                             \\"name\\": \\"S3IntegrationRoleF31D2F62\\",
                             \\"type\\": \\"Resource\\",
@@ -16033,13 +16033,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]8\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4161\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1164\\",
                             \\"name\\": \\"KeyPairProviderCustomResourceProviderHandlerBB6F16AF\\",
                             \\"type\\": \\"Resource\\",
@@ -16109,7 +16109,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3250\\",
                             \\"name\\": \\"KeyPairProviderCustomResourceProviderHandlerBB6F16AF\\",
                             \\"type\\": \\"Resource\\",
@@ -16182,13 +16182,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4300\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1496\\",
                             \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536\\",
                             \\"type\\": \\"Resource\\",
@@ -16261,7 +16261,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3378\\",
                             \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536\\",
                             \\"type\\": \\"Resource\\",
@@ -16339,13 +16339,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]12\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"4724\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1224\\",
                             \\"name\\": \\"InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                             \\"type\\": \\"Resource\\",
@@ -16385,7 +16385,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2563\\",
                             \\"name\\": \\"InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                             \\"type\\": \\"Resource\\",
@@ -16428,13 +16428,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"6202\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1590\\",
                             \\"name\\": \\"WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
                             \\"type\\": \\"Resource\\",
@@ -16547,7 +16547,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2801\\",
                             \\"name\\": \\"WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
                             \\"type\\": \\"Resource\\",
@@ -16663,13 +16663,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"7568\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1968\\",
                             \\"name\\": \\"S3IntegrationRoleDefaultPolicy5B77AE07\\",
                             \\"type\\": \\"Resource\\",
@@ -16729,7 +16729,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3179\\",
                             \\"name\\": \\"S3IntegrationRoleDefaultPolicy5B77AE07\\",
                             \\"type\\": \\"Resource\\",
@@ -16793,13 +16793,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]16\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"7725\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1233\\",
                             \\"name\\": \\"InstanceInstanceProfileAB5AEF02\\",
                             \\"type\\": \\"Resource\\",
@@ -16823,7 +16823,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2572\\",
                             \\"name\\": \\"InstanceInstanceProfileAB5AEF02\\",
                             \\"type\\": \\"Resource\\",
@@ -16851,13 +16851,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]18\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"8242\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1329\\",
                             \\"name\\": \\"WebAppBucket8F6FA179\\",
                             \\"type\\": \\"Resource\\",
@@ -16876,7 +16876,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2668\\",
                             \\"name\\": \\"WebAppBucket8F6FA179\\",
                             \\"type\\": \\"Resource\\",
@@ -16899,13 +16899,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]20\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"8467\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1652\\",
                             \\"name\\": \\"S3GatewayGameApp7F73230F\\",
                             \\"type\\": \\"Resource\\",
@@ -16928,7 +16928,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2863\\",
                             \\"name\\": \\"S3GatewayGameApp7F73230F\\",
                             \\"type\\": \\"Resource\\",
@@ -16954,13 +16954,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"8469\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1687\\",
                             \\"name\\": \\"S3GatewayGameAppAccount244C69A0\\",
                             \\"type\\": \\"Resource\\",
@@ -16988,7 +16988,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2898\\",
                             \\"name\\": \\"S3GatewayGameAppAccount244C69A0\\",
                             \\"type\\": \\"Resource\\",
@@ -17021,13 +17021,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]24\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"8582\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1762\\",
                             \\"name\\": \\"S3GatewayGameAppGET419DC6F4\\",
                             \\"type\\": \\"Resource\\",
@@ -17108,7 +17108,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2973\\",
                             \\"name\\": \\"S3GatewayGameAppGET419DC6F4\\",
                             \\"type\\": \\"Resource\\",
@@ -17192,13 +17192,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"8765\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1826\\",
                             \\"name\\": \\"S3GatewayGameAppproxyGET2D68D639\\",
                             \\"type\\": \\"Resource\\",
@@ -17282,7 +17282,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3037\\",
                             \\"name\\": \\"S3GatewayGameAppproxyGET2D68D639\\",
                             \\"type\\": \\"Resource\\",
@@ -17369,13 +17369,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"8938\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1921\\",
                             \\"name\\": \\"S3GatewayGameAppapiANY8309A6C9\\",
                             \\"type\\": \\"Resource\\",
@@ -17433,7 +17433,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3132\\",
                             \\"name\\": \\"S3GatewayGameAppapiANY8309A6C9\\",
                             \\"type\\": \\"Resource\\",
@@ -17494,13 +17494,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9080\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1775\\",
                             \\"name\\": \\"S3GatewayGameAppproxy2374A00B\\",
                             \\"type\\": \\"Resource\\",
@@ -17529,7 +17529,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2986\\",
                             \\"name\\": \\"S3GatewayGameAppproxy2374A00B\\",
                             \\"type\\": \\"Resource\\",
@@ -17561,13 +17561,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9093\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1839\\",
                             \\"name\\": \\"S3GatewayGameAppapi997B66C0\\",
                             \\"type\\": \\"Resource\\",
@@ -17596,7 +17596,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3050\\",
                             \\"name\\": \\"S3GatewayGameAppapi997B66C0\\",
                             \\"type\\": \\"Resource\\",
@@ -17628,13 +17628,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9104\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1865\\",
                             \\"name\\": \\"S3GatewayGameAppapiANYApiPermissionKesselRunStackS3GatewayGameAppDDC26D96ANYapi5CCFEF3A\\",
                             \\"type\\": \\"Resource\\",
@@ -17681,7 +17681,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3076\\",
                             \\"name\\": \\"S3GatewayGameAppapiANYApiPermissionKesselRunStackS3GatewayGameAppDDC26D96ANYapi5CCFEF3A\\",
                             \\"type\\": \\"Resource\\",
@@ -17731,13 +17731,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9320\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1888\\",
                             \\"name\\": \\"S3GatewayGameAppapiANYApiPermissionTestKesselRunStackS3GatewayGameAppDDC26D96ANYapi11815113\\",
                             \\"type\\": \\"Resource\\",
@@ -17780,7 +17780,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3099\\",
                             \\"name\\": \\"S3GatewayGameAppapiANYApiPermissionTestKesselRunStackS3GatewayGameAppDDC26D96ANYapi11815113\\",
                             \\"type\\": \\"Resource\\",
@@ -17826,13 +17826,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9432\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1975\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"Resource\\",
@@ -17852,7 +17852,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3385\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"Resource\\",
@@ -17875,13 +17875,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9433\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1979\\",
                             \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
                             \\"type\\": \\"Parameter\\",
@@ -17898,7 +17898,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3405\\",
                             \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
                             \\"type\\": \\"Parameter\\",
@@ -17918,13 +17918,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9446\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1983\\",
                             \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                             \\"type\\": \\"Parameter\\",
@@ -17941,7 +17941,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3409\\",
                             \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                             \\"type\\": \\"Parameter\\",
@@ -17961,13 +17961,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9459\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1987\\",
                             \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047ArtifactHashDD30B458\\",
                             \\"type\\": \\"Parameter\\",
@@ -17984,7 +17984,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3413\\",
                             \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047ArtifactHashDD30B458\\",
                             \\"type\\": \\"Parameter\\",
@@ -18004,13 +18004,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9472\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1991\\",
                             \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
                             \\"type\\": \\"Parameter\\",
@@ -18027,7 +18027,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3417\\",
                             \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
                             \\"type\\": \\"Parameter\\",
@@ -18047,13 +18047,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9485\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1995\\",
                             \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                             \\"type\\": \\"Parameter\\",
@@ -18070,7 +18070,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3421\\",
                             \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                             \\"type\\": \\"Parameter\\",
@@ -18090,13 +18090,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9498\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"1999\\",
                             \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176ArtifactHash4E343C6C\\",
                             \\"type\\": \\"Parameter\\",
@@ -18113,7 +18113,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3425\\",
                             \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176ArtifactHash4E343C6C\\",
                             \\"type\\": \\"Parameter\\",
@@ -18139,13 +18139,13 @@ exports[`Matching big template 1`] = `
             \\"[dup-ref]44\\",
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9835\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2027\\",
                             \\"name\\": \\"SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
                             \\"type\\": \\"Parameter\\",
@@ -18162,7 +18162,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3453\\",
                             \\"name\\": \\"SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
                             \\"type\\": \\"Parameter\\",
@@ -18182,13 +18182,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"9836\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2043\\",
                             \\"name\\": \\"S3GatewayGameAppEndpoint960301A3\\",
                             \\"type\\": \\"Output\\"
@@ -18222,7 +18222,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3401\\",
                             \\"name\\": \\"S3GatewayGameAppEndpoint960301A3\\",
                             \\"type\\": \\"Output\\"
@@ -18259,13 +18259,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"10433\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2187\\",
                             \\"name\\": \\"Role\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18280,7 +18280,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3693\\",
                             \\"name\\": \\"Role\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18298,13 +18298,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"10500\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2191\\",
                             \\"name\\": \\"Handler\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18319,7 +18319,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3697\\",
                             \\"name\\": \\"Handler\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18337,13 +18337,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"11875\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2223\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18358,7 +18358,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3701\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18376,13 +18376,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"12080\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2227\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18397,7 +18397,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3705\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18415,13 +18415,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"12285\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2231\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18436,7 +18436,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3709\\",
                             \\"name\\": \\"Resource\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18454,13 +18454,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"15436\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2303\\",
                             \\"name\\": \\"Default\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18475,7 +18475,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3713\\",
                             \\"name\\": \\"Default\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18493,13 +18493,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"15589\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2310\\",
                             \\"name\\": \\"KesselRunStack\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18514,7 +18514,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3723\\",
                             \\"name\\": \\"KesselRunStack\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18532,13 +18532,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"15825\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2325\\",
                             \\"name\\": \\"KeyPairProviderCustomResourceProvider\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18553,7 +18553,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3855\\",
                             \\"name\\": \\"KeyPairProviderCustomResourceProvider\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18571,13 +18571,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"16420\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2366\\",
                             \\"name\\": \\"ServiceRole\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18592,7 +18592,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3861\\",
                             \\"name\\": \\"ServiceRole\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18610,13 +18610,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"16487\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2369\\",
                             \\"name\\": \\"Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18631,7 +18631,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3864\\",
                             \\"name\\": \\"Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18649,13 +18649,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"16572\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2375\\",
                             \\"name\\": \\"DefaultPolicy\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18670,7 +18670,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3870\\",
                             \\"name\\": \\"DefaultPolicy\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18688,13 +18688,13 @@ exports[`Matching big template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"transition\\",
+                    \\"entityType\\": \\"transition\\",
                     \\"_id\\": \\"17869\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"v1\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"2462\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18709,7 +18709,7 @@ exports[`Matching big template 1`] = `
                     },
                     \\"v2\\": {
                         \\"nodeData\\": {
-                            \\"_entityType\\": \\"component\\",
+                            \\"entityType\\": \\"component\\",
                             \\"_id\\": \\"3876\\",
                             \\"name\\": \\"CDKMetadata\\",
                             \\"type\\": \\"CDK Construct\\"
@@ -18782,13 +18782,13 @@ exports[`Matching big template 1`] = `
         ],
         \\"infraModelTransition\\": {
             \\"nodeData\\": {
-                \\"_entityType\\": \\"transition\\",
+                \\"entityType\\": \\"transition\\",
                 \\"_id\\": \\"3880\\"
             },
             \\"outgoingNodeReferences\\": {
                 \\"v1\\": {
                     \\"nodeData\\": {
-                        \\"_entityType\\": \\"infrastructureState\\",
+                        \\"entityType\\": \\"infrastructureState\\",
                         \\"_id\\": \\"2465\\"
                     },
                     \\"outgoingNodeReferences\\": {
@@ -18909,7 +18909,7 @@ exports[`Matching big template 1`] = `
                         \\"relationships\\": [
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2092\\",
                                     \\"type\\": \\"Properties.UserName.Ref -> NVidiaUser1BAF4BFB\\",
                                     \\"sourcePropertyPath\\": [
@@ -18926,7 +18926,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2093\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> KeyPairProviderCustomResourceProviderHandlerBB6F16AF.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -18945,7 +18945,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2094\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
                                     \\"sourcePropertyPath\\": [
@@ -18963,7 +18963,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2095\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                                     \\"sourcePropertyPath\\": [
@@ -18988,7 +18988,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2096\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                                     \\"sourcePropertyPath\\": [
@@ -19013,7 +19013,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2097\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> KeyPairProviderCustomResourceProviderRoleA32FD897.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19032,7 +19032,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2098\\",
                                     \\"type\\": \\"DependsOn -> KeyPairProviderCustomResourceProviderRoleA32FD897\\",
                                     \\"sourcePropertyPath\\": [
@@ -19047,7 +19047,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2099\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                                     \\"sourcePropertyPath\\": [
@@ -19065,7 +19065,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2100\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                                     \\"sourcePropertyPath\\": [
@@ -19083,7 +19083,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2101\\",
                                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
                                     \\"sourcePropertyPath\\": [
@@ -19100,7 +19100,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2102\\",
                                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
                                     \\"sourcePropertyPath\\": [
@@ -19117,7 +19117,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2103\\",
                                     \\"type\\": \\"Properties.KeyName.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.KeyName\\",
                                     \\"sourcePropertyPath\\": [
@@ -19136,7 +19136,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2104\\",
                                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                                     \\"sourcePropertyPath\\": [
@@ -19156,7 +19156,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2105\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.1.Ref -> AccessKey\\",
                                     \\"sourcePropertyPath\\": [
@@ -19181,7 +19181,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2106\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.3.Fn::GetAtt -> AccessKey.SecretAccessKey\\",
                                     \\"sourcePropertyPath\\": [
@@ -19208,7 +19208,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2107\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                                     \\"sourcePropertyPath\\": [
@@ -19223,7 +19223,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2108\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
                                     \\"sourcePropertyPath\\": [
@@ -19238,7 +19238,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2109\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19257,7 +19257,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2110\\",
                                     \\"type\\": \\"Properties.SourceBucketNames.0.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
                                     \\"sourcePropertyPath\\": [
@@ -19275,7 +19275,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2111\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3VersionKeyE9526174\\",
                                     \\"sourcePropertyPath\\": [
@@ -19300,7 +19300,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2112\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3VersionKeyE9526174\\",
                                     \\"sourcePropertyPath\\": [
@@ -19325,7 +19325,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2113\\",
                                     \\"type\\": \\"Properties.DestinationBucketName.Ref -> WebAppBucket8F6FA179\\",
                                     \\"sourcePropertyPath\\": [
@@ -19342,7 +19342,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2114\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::Join.1.3.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
                                     \\"sourcePropertyPath\\": [
@@ -19366,7 +19366,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2115\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.3.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
                                     \\"sourcePropertyPath\\": [
@@ -19390,7 +19390,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2116\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19413,7 +19413,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2117\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19439,7 +19439,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2118\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                                     \\"sourcePropertyPath\\": [
@@ -19457,7 +19457,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2119\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
                                     \\"sourcePropertyPath\\": [
@@ -19475,7 +19475,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2120\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                                     \\"sourcePropertyPath\\": [
@@ -19500,7 +19500,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2121\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                                     \\"sourcePropertyPath\\": [
@@ -19525,7 +19525,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2122\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19544,7 +19544,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2123\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
                                     \\"sourcePropertyPath\\": [
@@ -19559,7 +19559,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2124\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                                     \\"sourcePropertyPath\\": [
@@ -19574,7 +19574,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2125\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.Fn::Join.1.3.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                                     \\"sourcePropertyPath\\": [
@@ -19599,7 +19599,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2126\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.2.Resource.Fn::Join.1.3.Ref -> InstanceC1063A87\\",
                                     \\"sourcePropertyPath\\": [
@@ -19622,7 +19622,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2127\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.3.Resource.Fn::Join.1.3.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
                                     \\"sourcePropertyPath\\": [
@@ -19647,7 +19647,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2128\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> WebAppLambdaServiceRoleB3C5DDDA\\",
                                     \\"sourcePropertyPath\\": [
@@ -19665,7 +19665,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2129\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3Bucket5BA77413\\",
                                     \\"sourcePropertyPath\\": [
@@ -19683,7 +19683,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2130\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3VersionKey484CA5B8\\",
                                     \\"sourcePropertyPath\\": [
@@ -19708,7 +19708,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2131\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3VersionKey484CA5B8\\",
                                     \\"sourcePropertyPath\\": [
@@ -19733,7 +19733,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2132\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> WebAppLambdaServiceRoleB3C5DDDA.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19752,7 +19752,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2133\\",
                                     \\"type\\": \\"Properties.Environment.Variables.INSTANCE_ID.Ref -> InstanceC1063A87\\",
                                     \\"sourcePropertyPath\\": [
@@ -19771,7 +19771,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2134\\",
                                     \\"type\\": \\"Properties.Environment.Variables.SECURITY_GROUP_ID.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                                     \\"sourcePropertyPath\\": [
@@ -19792,7 +19792,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2135\\",
                                     \\"type\\": \\"Properties.Environment.Variables.KEY_PARAMETER_NAME.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
                                     \\"sourcePropertyPath\\": [
@@ -19813,7 +19813,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2136\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
                                     \\"sourcePropertyPath\\": [
@@ -19828,7 +19828,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2137\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleB3C5DDDA\\",
                                     \\"sourcePropertyPath\\": [
@@ -19843,7 +19843,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2138\\",
                                     \\"type\\": \\"Properties.CloudWatchRoleArn.Fn::GetAtt -> S3GatewayGameAppCloudWatchRole3E18F736.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -19862,7 +19862,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2139\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -19877,7 +19877,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2140\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -19894,7 +19894,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2141\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxyGET2D68D639\\",
                                     \\"sourcePropertyPath\\": [
@@ -19909,7 +19909,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2142\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxy2374A00B\\",
                                     \\"sourcePropertyPath\\": [
@@ -19924,7 +19924,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2143\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapiANY8309A6C9\\",
                                     \\"sourcePropertyPath\\": [
@@ -19939,7 +19939,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2144\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapi997B66C0\\",
                                     \\"sourcePropertyPath\\": [
@@ -19954,7 +19954,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2145\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppGET419DC6F4\\",
                                     \\"sourcePropertyPath\\": [
@@ -19969,7 +19969,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2146\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -19986,7 +19986,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2147\\",
                                     \\"type\\": \\"Properties.DeploymentId.Ref -> S3GatewayGameAppDeployment45A40F1C4b3c56c977a48268e4d338b071d20578\\",
                                     \\"sourcePropertyPath\\": [
@@ -20003,7 +20003,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2148\\",
                                     \\"type\\": \\"Properties.ResourceId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                                     \\"sourcePropertyPath\\": [
@@ -20022,7 +20022,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2149\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20039,7 +20039,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2150\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20059,7 +20059,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2151\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
                                     \\"sourcePropertyPath\\": [
@@ -20080,7 +20080,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2152\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                                     \\"sourcePropertyPath\\": [
@@ -20099,7 +20099,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2153\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20116,7 +20116,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2154\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppproxy2374A00B\\",
                                     \\"sourcePropertyPath\\": [
@@ -20133,7 +20133,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2155\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20150,7 +20150,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2156\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20170,7 +20170,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2157\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
                                     \\"sourcePropertyPath\\": [
@@ -20191,7 +20191,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2158\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                                     \\"sourcePropertyPath\\": [
@@ -20210,7 +20210,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2159\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20227,7 +20227,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2160\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20246,7 +20246,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2161\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20266,7 +20266,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2162\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
                                     \\"sourcePropertyPath\\": [
@@ -20286,7 +20286,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2163\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20305,7 +20305,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2164\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20325,7 +20325,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2165\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppapi997B66C0\\",
                                     \\"sourcePropertyPath\\": [
@@ -20342,7 +20342,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2166\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20359,7 +20359,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2167\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20382,7 +20382,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2168\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20405,7 +20405,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2169\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -20431,7 +20431,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2170\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> S3IntegrationRoleF31D2F62\\",
                                     \\"sourcePropertyPath\\": [
@@ -20449,7 +20449,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2171\\",
                                     \\"type\\": \\"Value.Fn::Join.1.1.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -20468,7 +20468,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2172\\",
                                     \\"type\\": \\"Value.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
                                     \\"sourcePropertyPath\\": [
@@ -20487,7 +20487,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2176\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20498,7 +20498,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2180\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20509,7 +20509,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2184\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20520,7 +20520,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2188\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20531,7 +20531,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2192\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20542,7 +20542,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2196\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20553,7 +20553,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2200\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20564,7 +20564,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2204\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20575,7 +20575,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2208\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20586,7 +20586,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2212\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20597,7 +20597,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2216\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20608,7 +20608,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2220\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20619,7 +20619,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2224\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20630,7 +20630,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2228\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20641,7 +20641,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2232\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20652,7 +20652,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2236\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20663,7 +20663,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2240\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20674,7 +20674,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2244\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20685,7 +20685,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2248\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20696,7 +20696,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2252\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20707,7 +20707,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2256\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20718,7 +20718,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2260\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20729,7 +20729,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2264\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20740,7 +20740,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2268\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20751,7 +20751,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2272\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20762,7 +20762,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2276\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20773,7 +20773,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2280\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20784,7 +20784,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2284\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20795,7 +20795,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2288\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20806,7 +20806,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2292\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20817,7 +20817,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2296\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20828,7 +20828,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2300\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20839,7 +20839,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2304\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -20850,7 +20850,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2312\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20861,7 +20861,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2311\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20872,7 +20872,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2313\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20883,7 +20883,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2320\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20894,7 +20894,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2326\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20905,7 +20905,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2335\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20916,7 +20916,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2353\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20927,7 +20927,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2361\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20938,7 +20938,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2370\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20949,7 +20949,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2385\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20960,7 +20960,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2400\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20971,7 +20971,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2453\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20982,7 +20982,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2463\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -20993,7 +20993,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2322\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21004,7 +21004,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2321\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21015,7 +21015,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2327\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21026,7 +21026,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2328\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21037,7 +21037,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2337\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21048,7 +21048,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2336\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21059,7 +21059,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2341\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21070,7 +21070,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2348\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21081,7 +21081,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2349\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21092,7 +21092,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2342\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21103,7 +21103,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2346\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21114,7 +21114,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2347\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21125,7 +21125,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2354\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21136,7 +21136,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2363\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21147,7 +21147,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2362\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21158,7 +21158,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2372\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21169,7 +21169,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2376\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21180,7 +21180,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2371\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21191,7 +21191,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2378\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21202,7 +21202,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2377\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21213,7 +21213,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2387\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21224,7 +21224,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2391\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21235,7 +21235,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2386\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21246,7 +21246,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2393\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21257,7 +21257,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2392\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21268,7 +21268,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2402\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21279,7 +21279,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2406\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21290,7 +21290,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2408\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21301,7 +21301,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2412\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21312,7 +21312,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2417\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21323,7 +21323,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2425\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21334,7 +21334,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2401\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21345,7 +21345,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2407\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21356,7 +21356,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2413\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21367,7 +21367,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2418\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21378,7 +21378,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2427\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21389,7 +21389,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2426\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21400,7 +21400,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2431\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21411,7 +21411,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2441\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21422,7 +21422,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2432\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21433,7 +21433,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2436\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21444,7 +21444,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2437\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21455,7 +21455,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2442\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21466,7 +21466,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2446\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21477,7 +21477,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2447\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21488,7 +21488,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2448\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21499,7 +21499,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2449\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21510,7 +21510,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2454\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21521,7 +21521,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2458\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21532,7 +21532,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2459\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21543,7 +21543,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2464\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -21557,7 +21557,7 @@ exports[`Matching big template 1`] = `
                 },
                 \\"v2\\": {
                     \\"nodeData\\": {
-                        \\"_entityType\\": \\"infrastructureState\\",
+                        \\"entityType\\": \\"infrastructureState\\",
                         \\"_id\\": \\"3879\\"
                     },
                     \\"outgoingNodeReferences\\": {
@@ -21679,7 +21679,7 @@ exports[`Matching big template 1`] = `
                         \\"relationships\\": [
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3502\\",
                                     \\"type\\": \\"Properties.UserName.Ref -> NVidiaUser1BAF4BFB\\",
                                     \\"sourcePropertyPath\\": [
@@ -21696,7 +21696,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3503\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> KeyPairProviderCustomResourceProviderHandlerBB6F16AF.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -21715,7 +21715,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3504\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                                     \\"sourcePropertyPath\\": [
@@ -21733,7 +21733,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3505\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                                     \\"sourcePropertyPath\\": [
@@ -21751,7 +21751,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3506\\",
                                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
                                     \\"sourcePropertyPath\\": [
@@ -21768,7 +21768,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3507\\",
                                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
                                     \\"sourcePropertyPath\\": [
@@ -21785,7 +21785,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3508\\",
                                     \\"type\\": \\"Properties.KeyName.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.KeyName\\",
                                     \\"sourcePropertyPath\\": [
@@ -21804,7 +21804,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3509\\",
                                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                                     \\"sourcePropertyPath\\": [
@@ -21824,7 +21824,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3510\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.1.Ref -> AccessKey\\",
                                     \\"sourcePropertyPath\\": [
@@ -21849,7 +21849,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3511\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.3.Fn::GetAtt -> AccessKey.SecretAccessKey\\",
                                     \\"sourcePropertyPath\\": [
@@ -21876,7 +21876,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3512\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                                     \\"sourcePropertyPath\\": [
@@ -21891,7 +21891,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3513\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
                                     \\"sourcePropertyPath\\": [
@@ -21906,7 +21906,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3514\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -21925,7 +21925,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3515\\",
                                     \\"type\\": \\"Properties.SourceBucketNames.0.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                                     \\"sourcePropertyPath\\": [
@@ -21943,7 +21943,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3516\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
                                     \\"sourcePropertyPath\\": [
@@ -21968,7 +21968,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3517\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
                                     \\"sourcePropertyPath\\": [
@@ -21993,7 +21993,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3518\\",
                                     \\"type\\": \\"Properties.DestinationBucketName.Ref -> WebAppBucket8F6FA179\\",
                                     \\"sourcePropertyPath\\": [
@@ -22010,7 +22010,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3519\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.Fn::Join.1.3.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                                     \\"sourcePropertyPath\\": [
@@ -22035,7 +22035,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3520\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.2.Resource.Fn::Join.1.3.Ref -> InstanceC1063A87\\",
                                     \\"sourcePropertyPath\\": [
@@ -22058,7 +22058,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3521\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.3.Resource.Fn::Join.1.3.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
                                     \\"sourcePropertyPath\\": [
@@ -22083,7 +22083,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3522\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> WebAppLambdaServiceRoleB3C5DDDA\\",
                                     \\"sourcePropertyPath\\": [
@@ -22101,7 +22101,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3523\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3BucketA30C151C\\",
                                     \\"sourcePropertyPath\\": [
@@ -22119,7 +22119,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3524\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
                                     \\"sourcePropertyPath\\": [
@@ -22144,7 +22144,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3525\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
                                     \\"sourcePropertyPath\\": [
@@ -22169,7 +22169,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3526\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> WebAppLambdaServiceRoleB3C5DDDA.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22188,7 +22188,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3527\\",
                                     \\"type\\": \\"Properties.Environment.Variables.INSTANCE_ID.Ref -> InstanceC1063A87\\",
                                     \\"sourcePropertyPath\\": [
@@ -22207,7 +22207,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3528\\",
                                     \\"type\\": \\"Properties.Environment.Variables.SECURITY_GROUP_ID.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                                     \\"sourcePropertyPath\\": [
@@ -22228,7 +22228,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3529\\",
                                     \\"type\\": \\"Properties.Environment.Variables.KEY_PARAMETER_NAME.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
                                     \\"sourcePropertyPath\\": [
@@ -22249,7 +22249,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3530\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
                                     \\"sourcePropertyPath\\": [
@@ -22264,7 +22264,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3531\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleB3C5DDDA\\",
                                     \\"sourcePropertyPath\\": [
@@ -22279,7 +22279,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3532\\",
                                     \\"type\\": \\"Properties.CloudWatchRoleArn.Fn::GetAtt -> S3GatewayGameAppCloudWatchRole3E18F736.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22298,7 +22298,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3533\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22313,7 +22313,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3534\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22330,7 +22330,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3535\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxyGET2D68D639\\",
                                     \\"sourcePropertyPath\\": [
@@ -22345,7 +22345,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3536\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxy2374A00B\\",
                                     \\"sourcePropertyPath\\": [
@@ -22360,7 +22360,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3537\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapiANY8309A6C9\\",
                                     \\"sourcePropertyPath\\": [
@@ -22375,7 +22375,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3538\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapi997B66C0\\",
                                     \\"sourcePropertyPath\\": [
@@ -22390,7 +22390,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3539\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppGET419DC6F4\\",
                                     \\"sourcePropertyPath\\": [
@@ -22405,7 +22405,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3540\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22422,7 +22422,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3541\\",
                                     \\"type\\": \\"Properties.DeploymentId.Ref -> S3GatewayGameAppDeployment45A40F1C1ea3f370273feac6dc79badcdb1c5090\\",
                                     \\"sourcePropertyPath\\": [
@@ -22439,7 +22439,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3542\\",
                                     \\"type\\": \\"Properties.ResourceId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                                     \\"sourcePropertyPath\\": [
@@ -22458,7 +22458,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3543\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22475,7 +22475,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3544\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22495,7 +22495,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3545\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
                                     \\"sourcePropertyPath\\": [
@@ -22516,7 +22516,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3546\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                                     \\"sourcePropertyPath\\": [
@@ -22535,7 +22535,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3547\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22552,7 +22552,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3548\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppproxy2374A00B\\",
                                     \\"sourcePropertyPath\\": [
@@ -22569,7 +22569,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3549\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22586,7 +22586,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3550\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22606,7 +22606,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3551\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
                                     \\"sourcePropertyPath\\": [
@@ -22627,7 +22627,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3552\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                                     \\"sourcePropertyPath\\": [
@@ -22646,7 +22646,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3553\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22663,7 +22663,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3554\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22682,7 +22682,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3555\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22702,7 +22702,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3556\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
                                     \\"sourcePropertyPath\\": [
@@ -22722,7 +22722,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3557\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22741,7 +22741,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3558\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22761,7 +22761,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3559\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppapi997B66C0\\",
                                     \\"sourcePropertyPath\\": [
@@ -22778,7 +22778,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3560\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -22795,7 +22795,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3561\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22818,7 +22818,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3562\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22841,7 +22841,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3563\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22867,7 +22867,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3564\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> S3IntegrationRoleF31D2F62\\",
                                     \\"sourcePropertyPath\\": [
@@ -22885,7 +22885,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3565\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
                                     \\"sourcePropertyPath\\": [
@@ -22903,7 +22903,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3566\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                                     \\"sourcePropertyPath\\": [
@@ -22928,7 +22928,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3567\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                                     \\"sourcePropertyPath\\": [
@@ -22953,7 +22953,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3568\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> KeyPairProviderCustomResourceProviderRoleA32FD897.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -22972,7 +22972,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3569\\",
                                     \\"type\\": \\"DependsOn -> KeyPairProviderCustomResourceProviderRoleA32FD897\\",
                                     \\"sourcePropertyPath\\": [
@@ -22987,7 +22987,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3570\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                                     \\"sourcePropertyPath\\": [
@@ -23011,7 +23011,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3571\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                                     \\"sourcePropertyPath\\": [
@@ -23035,7 +23035,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3572\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -23058,7 +23058,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3573\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -23084,7 +23084,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3574\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                                     \\"sourcePropertyPath\\": [
@@ -23102,7 +23102,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3575\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
                                     \\"sourcePropertyPath\\": [
@@ -23120,7 +23120,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3576\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                                     \\"sourcePropertyPath\\": [
@@ -23145,7 +23145,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3577\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                                     \\"sourcePropertyPath\\": [
@@ -23170,7 +23170,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3578\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265.Arn\\",
                                     \\"sourcePropertyPath\\": [
@@ -23189,7 +23189,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3579\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
                                     \\"sourcePropertyPath\\": [
@@ -23204,7 +23204,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3580\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                                     \\"sourcePropertyPath\\": [
@@ -23219,7 +23219,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3581\\",
                                     \\"type\\": \\"Value.Fn::Join.1.1.Ref -> S3GatewayGameApp7F73230F\\",
                                     \\"sourcePropertyPath\\": [
@@ -23238,7 +23238,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3582\\",
                                     \\"type\\": \\"Value.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
                                     \\"sourcePropertyPath\\": [
@@ -23257,7 +23257,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3586\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23268,7 +23268,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3590\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23279,7 +23279,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3594\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23290,7 +23290,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3598\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23301,7 +23301,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3602\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23312,7 +23312,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3606\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23323,7 +23323,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3610\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23334,7 +23334,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3614\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23345,7 +23345,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3618\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23356,7 +23356,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3622\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23367,7 +23367,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3626\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23378,7 +23378,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3630\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23389,7 +23389,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3634\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23400,7 +23400,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3638\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23411,7 +23411,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3642\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23422,7 +23422,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3646\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23433,7 +23433,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3650\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23444,7 +23444,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3654\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23455,7 +23455,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3658\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23466,7 +23466,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3662\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23477,7 +23477,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3666\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23488,7 +23488,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3670\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23499,7 +23499,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3674\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23510,7 +23510,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3678\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23521,7 +23521,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3682\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23532,7 +23532,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3686\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23543,7 +23543,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3690\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23554,7 +23554,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3694\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23565,7 +23565,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3698\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23576,7 +23576,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3702\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23587,7 +23587,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3706\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23598,7 +23598,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3710\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23609,7 +23609,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3714\\",
                                     \\"type\\": \\"construct-resource\\"
                                 },
@@ -23620,7 +23620,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3726\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23631,7 +23631,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3725\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23642,7 +23642,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3727\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23653,7 +23653,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3734\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23664,7 +23664,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3743\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23675,7 +23675,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3761\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23686,7 +23686,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3769\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23697,7 +23697,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3778\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23708,7 +23708,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3793\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23719,7 +23719,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3846\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23730,7 +23730,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3724\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23741,7 +23741,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3856\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23752,7 +23752,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3865\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23763,7 +23763,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3877\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23774,7 +23774,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3736\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23785,7 +23785,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3735\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23796,7 +23796,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3745\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23807,7 +23807,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3744\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23818,7 +23818,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3749\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23829,7 +23829,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3756\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23840,7 +23840,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3757\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23851,7 +23851,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3750\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23862,7 +23862,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3754\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23873,7 +23873,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3755\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23884,7 +23884,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3762\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23895,7 +23895,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3771\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23906,7 +23906,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3770\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23917,7 +23917,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3780\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23928,7 +23928,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3784\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23939,7 +23939,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3779\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23950,7 +23950,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3786\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23961,7 +23961,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3785\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23972,7 +23972,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3795\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23983,7 +23983,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3799\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -23994,7 +23994,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3801\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24005,7 +24005,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3805\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24016,7 +24016,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3810\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24027,7 +24027,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3818\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24038,7 +24038,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3794\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24049,7 +24049,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3800\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24060,7 +24060,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3806\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24071,7 +24071,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3811\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24082,7 +24082,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3820\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24093,7 +24093,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3819\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24104,7 +24104,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3824\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24115,7 +24115,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3834\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24126,7 +24126,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3825\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24137,7 +24137,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3829\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24148,7 +24148,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3830\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24159,7 +24159,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3835\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24170,7 +24170,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3839\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24181,7 +24181,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3840\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24192,7 +24192,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3841\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24203,7 +24203,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3842\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24214,7 +24214,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3847\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24225,7 +24225,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3851\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24236,7 +24236,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3852\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24247,7 +24247,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3857\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24258,7 +24258,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3858\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24269,7 +24269,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3867\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24280,7 +24280,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3871\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24291,7 +24291,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3866\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24302,7 +24302,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3873\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24313,7 +24313,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3872\\",
                                     \\"type\\": \\"construct\\"
                                 },
@@ -24324,7 +24324,7 @@ exports[`Matching big template 1`] = `
                             },
                             {
                                 \\"nodeData\\": {
-                                    \\"_entityType\\": \\"relationship\\",
+                                    \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3878\\",
                                     \\"type\\": \\"construct\\"
                                 },

--- a/packages/change-analysis/test/platform-mapping/cdk/__snapshots__/cdk-parser.test.ts.snap
+++ b/packages/change-analysis/test/platform-mapping/cdk/__snapshots__/cdk-parser.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`CDK kessel run stack template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"infrastructureState\\",
+        \\"entityType\\": \\"infrastructureState\\",
         \\"_id\\": \\"1588\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"components\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"191\\",
                     \\"name\\": \\"NVidiaUser1BAF4BFB\\",
                     \\"type\\": \\"Resource\\",
@@ -43,7 +43,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"199\\",
                     \\"name\\": \\"AccessKey\\",
                     \\"type\\": \\"Resource\\",
@@ -65,7 +65,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"212\\",
                     \\"name\\": \\"GameKeyKeyPairF8B1B0F0\\",
                     \\"type\\": \\"Resource\\",
@@ -93,7 +93,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"234\\",
                     \\"name\\": \\"InstanceInstanceSecurityGroupF0E2D5BE\\",
                     \\"type\\": \\"Resource\\",
@@ -134,7 +134,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"252\\",
                     \\"name\\": \\"InstanceInstanceRoleE9785DE5\\",
                     \\"type\\": \\"Resource\\",
@@ -171,7 +171,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"272\\",
                     \\"name\\": \\"InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                     \\"type\\": \\"Resource\\",
@@ -211,7 +211,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"281\\",
                     \\"name\\": \\"InstanceInstanceProfileAB5AEF02\\",
                     \\"type\\": \\"Resource\\",
@@ -235,7 +235,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"370\\",
                     \\"name\\": \\"InstanceC1063A87\\",
                     \\"type\\": \\"Resource\\",
@@ -377,7 +377,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"377\\",
                     \\"name\\": \\"WebAppBucket8F6FA179\\",
                     \\"type\\": \\"Resource\\",
@@ -396,7 +396,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"416\\",
                     \\"name\\": \\"WebAppDeploymentCustomResourceD7DB25D0\\",
                     \\"type\\": \\"Resource\\",
@@ -467,7 +467,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"439\\",
                     \\"name\\": \\"WebAppLambdaServiceRoleB3C5DDDA\\",
                     \\"type\\": \\"Resource\\",
@@ -512,7 +512,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"510\\",
                     \\"name\\": \\"WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
                     \\"type\\": \\"Resource\\",
@@ -625,7 +625,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"563\\",
                     \\"name\\": \\"WebAppLambdaE4C4A83F\\",
                     \\"type\\": \\"Resource\\",
@@ -717,7 +717,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"572\\",
                     \\"name\\": \\"S3GatewayGameApp7F73230F\\",
                     \\"type\\": \\"Resource\\",
@@ -740,7 +740,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"595\\",
                     \\"name\\": \\"S3GatewayGameAppCloudWatchRole3E18F736\\",
                     \\"type\\": \\"Resource\\",
@@ -785,7 +785,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"607\\",
                     \\"name\\": \\"S3GatewayGameAppAccount244C69A0\\",
                     \\"type\\": \\"Resource\\",
@@ -813,7 +813,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"622\\",
                     \\"name\\": \\"S3GatewayGameAppDeployment45A40F1C1ea3f370273feac6dc79badcdb1c5090\\",
                     \\"type\\": \\"Resource\\",
@@ -843,7 +843,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"633\\",
                     \\"name\\": \\"S3GatewayGameAppDeploymentStageprod501ACE37\\",
                     \\"type\\": \\"Resource\\",
@@ -869,7 +869,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"682\\",
                     \\"name\\": \\"S3GatewayGameAppGET419DC6F4\\",
                     \\"type\\": \\"Resource\\",
@@ -950,7 +950,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"695\\",
                     \\"name\\": \\"S3GatewayGameAppproxy2374A00B\\",
                     \\"type\\": \\"Resource\\",
@@ -979,7 +979,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"746\\",
                     \\"name\\": \\"S3GatewayGameAppproxyGET2D68D639\\",
                     \\"type\\": \\"Resource\\",
@@ -1063,7 +1063,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"759\\",
                     \\"name\\": \\"S3GatewayGameAppapi997B66C0\\",
                     \\"type\\": \\"Resource\\",
@@ -1092,7 +1092,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"785\\",
                     \\"name\\": \\"S3GatewayGameAppapiANYApiPermissionKesselRunStackS3GatewayGameAppDDC26D96ANYapi5CCFEF3A\\",
                     \\"type\\": \\"Resource\\",
@@ -1139,7 +1139,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"808\\",
                     \\"name\\": \\"S3GatewayGameAppapiANYApiPermissionTestKesselRunStackS3GatewayGameAppDDC26D96ANYapi11815113\\",
                     \\"type\\": \\"Resource\\",
@@ -1182,7 +1182,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"841\\",
                     \\"name\\": \\"S3GatewayGameAppapiANY8309A6C9\\",
                     \\"type\\": \\"Resource\\",
@@ -1240,7 +1240,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"855\\",
                     \\"name\\": \\"S3IntegrationRoleF31D2F62\\",
                     \\"type\\": \\"Resource\\",
@@ -1271,7 +1271,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"888\\",
                     \\"name\\": \\"S3IntegrationRoleDefaultPolicy5B77AE07\\",
                     \\"type\\": \\"Resource\\",
@@ -1331,7 +1331,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"920\\",
                     \\"name\\": \\"KeyPairProviderCustomResourceProviderRoleA32FD897\\",
                     \\"type\\": \\"Resource\\",
@@ -1389,7 +1389,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"959\\",
                     \\"name\\": \\"KeyPairProviderCustomResourceProviderHandlerBB6F16AF\\",
                     \\"type\\": \\"Resource\\",
@@ -1459,7 +1459,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"982\\",
                     \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                     \\"type\\": \\"Resource\\",
@@ -1504,7 +1504,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1046\\",
                     \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
                     \\"type\\": \\"Resource\\",
@@ -1608,7 +1608,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1087\\",
                     \\"name\\": \\"CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536\\",
                     \\"type\\": \\"Resource\\",
@@ -1681,7 +1681,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1094\\",
                     \\"name\\": \\"CDKMetadata\\",
                     \\"type\\": \\"Resource\\",
@@ -1701,7 +1701,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1110\\",
                     \\"name\\": \\"S3GatewayGameAppEndpoint960301A3\\",
                     \\"type\\": \\"Output\\"
@@ -1735,7 +1735,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1114\\",
                     \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
                     \\"type\\": \\"Parameter\\",
@@ -1752,7 +1752,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1118\\",
                     \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                     \\"type\\": \\"Parameter\\",
@@ -1769,7 +1769,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1122\\",
                     \\"name\\": \\"AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047ArtifactHashDD30B458\\",
                     \\"type\\": \\"Parameter\\",
@@ -1786,7 +1786,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1126\\",
                     \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
                     \\"type\\": \\"Parameter\\",
@@ -1803,7 +1803,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1130\\",
                     \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                     \\"type\\": \\"Parameter\\",
@@ -1820,7 +1820,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1134\\",
                     \\"name\\": \\"AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176ArtifactHash4E343C6C\\",
                     \\"type\\": \\"Parameter\\",
@@ -1837,7 +1837,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1138\\",
                     \\"name\\": \\"AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                     \\"type\\": \\"Parameter\\",
@@ -1854,7 +1854,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1142\\",
                     \\"name\\": \\"AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
                     \\"type\\": \\"Parameter\\",
@@ -1871,7 +1871,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1146\\",
                     \\"name\\": \\"AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fArtifactHashE5AC1E7E\\",
                     \\"type\\": \\"Parameter\\",
@@ -1888,7 +1888,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1150\\",
                     \\"name\\": \\"AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3BucketA30C151C\\",
                     \\"type\\": \\"Parameter\\",
@@ -1905,7 +1905,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1154\\",
                     \\"name\\": \\"AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
                     \\"type\\": \\"Parameter\\",
@@ -1922,7 +1922,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1158\\",
                     \\"name\\": \\"AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7ArtifactHash6C4D52FA\\",
                     \\"type\\": \\"Parameter\\",
@@ -1939,7 +1939,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1162\\",
                     \\"name\\": \\"SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
                     \\"type\\": \\"Parameter\\",
@@ -1956,7 +1956,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1294\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -1971,7 +1971,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1298\\",
                     \\"name\\": \\"AccessKey\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -1986,7 +1986,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1302\\",
                     \\"name\\": \\"Default\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2001,7 +2001,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1306\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2016,7 +2016,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1310\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2031,7 +2031,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1314\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2046,7 +2046,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1318\\",
                     \\"name\\": \\"InstanceProfile\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2061,7 +2061,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1322\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2076,7 +2076,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1326\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2091,7 +2091,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1330\\",
                     \\"name\\": \\"Default\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2106,7 +2106,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1334\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2121,7 +2121,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1338\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2136,7 +2136,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1342\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2151,7 +2151,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1346\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2166,7 +2166,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1350\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2181,7 +2181,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1354\\",
                     \\"name\\": \\"Account\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2196,7 +2196,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1358\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2211,7 +2211,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1362\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2226,7 +2226,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1366\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2241,7 +2241,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1370\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2256,7 +2256,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1374\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2271,7 +2271,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1378\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2286,7 +2286,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1382\\",
                     \\"name\\": \\"ApiPermission.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2301,7 +2301,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1386\\",
                     \\"name\\": \\"ApiPermission.Test.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2316,7 +2316,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1390\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2331,7 +2331,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1394\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2346,7 +2346,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1398\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2361,7 +2361,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1402\\",
                     \\"name\\": \\"Role\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2376,7 +2376,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1406\\",
                     \\"name\\": \\"Handler\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2391,7 +2391,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1410\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2406,7 +2406,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1414\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2421,7 +2421,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1418\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2436,7 +2436,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1422\\",
                     \\"name\\": \\"Default\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2451,7 +2451,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1426\\",
                     \\"name\\": \\"NVidiaUser\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2466,7 +2466,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1429\\",
                     \\"name\\": \\"Default\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2481,7 +2481,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1432\\",
                     \\"name\\": \\"KesselRunStack\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2496,7 +2496,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1439\\",
                     \\"name\\": \\"KeyPair\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2511,7 +2511,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1442\\",
                     \\"name\\": \\"GameKey\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2526,7 +2526,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1448\\",
                     \\"name\\": \\"InstanceSecurityGroup\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2541,7 +2541,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1451\\",
                     \\"name\\": \\"Instance\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2556,7 +2556,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1457\\",
                     \\"name\\": \\"InstanceRole\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2571,7 +2571,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1462\\",
                     \\"name\\": \\"DefaultPolicy\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2586,7 +2586,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1469\\",
                     \\"name\\": \\"WebAppBucket\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2601,7 +2601,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1474\\",
                     \\"name\\": \\"CustomResource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2616,7 +2616,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1477\\",
                     \\"name\\": \\"WebAppDeployment\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2631,7 +2631,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1483\\",
                     \\"name\\": \\"ServiceRole\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2646,7 +2646,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1486\\",
                     \\"name\\": \\"WebAppLambda\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2661,7 +2661,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1492\\",
                     \\"name\\": \\"DefaultPolicy\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2676,7 +2676,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1498\\",
                     \\"name\\": \\"GameApp\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2691,7 +2691,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1501\\",
                     \\"name\\": \\"S3Gateway\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2706,7 +2706,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1507\\",
                     \\"name\\": \\"CloudWatchRole\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2721,7 +2721,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1513\\",
                     \\"name\\": \\"Deployment\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2736,7 +2736,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1518\\",
                     \\"name\\": \\"DeploymentStage.prod\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2751,7 +2751,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1523\\",
                     \\"name\\": \\"GET\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2766,7 +2766,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1526\\",
                     \\"name\\": \\"Default\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2781,7 +2781,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1532\\",
                     \\"name\\": \\"{proxy+}\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2796,7 +2796,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1537\\",
                     \\"name\\": \\"GET\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2811,7 +2811,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1542\\",
                     \\"name\\": \\"api\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2826,7 +2826,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1547\\",
                     \\"name\\": \\"ANY\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2841,7 +2841,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1554\\",
                     \\"name\\": \\"S3IntegrationRole\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2856,7 +2856,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1559\\",
                     \\"name\\": \\"DefaultPolicy\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2871,7 +2871,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1564\\",
                     \\"name\\": \\"KeyPairProviderCustomResourceProvider\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2886,7 +2886,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1570\\",
                     \\"name\\": \\"ServiceRole\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2901,7 +2901,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1573\\",
                     \\"name\\": \\"Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2916,7 +2916,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1579\\",
                     \\"name\\": \\"DefaultPolicy\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2931,7 +2931,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"1585\\",
                     \\"name\\": \\"CDKMetadata\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -2948,7 +2948,7 @@ exports[`CDK kessel run stack template 1`] = `
         \\"relationships\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1211\\",
                     \\"type\\": \\"Properties.UserName.Ref -> NVidiaUser1BAF4BFB\\",
                     \\"sourcePropertyPath\\": [
@@ -2965,7 +2965,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1212\\",
                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> KeyPairProviderCustomResourceProviderHandlerBB6F16AF.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -2984,7 +2984,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1213\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                     \\"sourcePropertyPath\\": [
@@ -3002,7 +3002,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1214\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                     \\"sourcePropertyPath\\": [
@@ -3020,7 +3020,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1215\\",
                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
                     \\"sourcePropertyPath\\": [
@@ -3037,7 +3037,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1216\\",
                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
                     \\"sourcePropertyPath\\": [
@@ -3054,7 +3054,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1217\\",
                     \\"type\\": \\"Properties.KeyName.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.KeyName\\",
                     \\"sourcePropertyPath\\": [
@@ -3073,7 +3073,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1218\\",
                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                     \\"sourcePropertyPath\\": [
@@ -3093,7 +3093,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1219\\",
                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.1.Ref -> AccessKey\\",
                     \\"sourcePropertyPath\\": [
@@ -3118,7 +3118,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1220\\",
                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.3.Fn::GetAtt -> AccessKey.SecretAccessKey\\",
                     \\"sourcePropertyPath\\": [
@@ -3145,7 +3145,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1221\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                     \\"sourcePropertyPath\\": [
@@ -3160,7 +3160,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1222\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
                     \\"sourcePropertyPath\\": [
@@ -3175,7 +3175,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1223\\",
                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3194,7 +3194,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1224\\",
                     \\"type\\": \\"Properties.SourceBucketNames.0.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                     \\"sourcePropertyPath\\": [
@@ -3212,7 +3212,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1225\\",
                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
                     \\"sourcePropertyPath\\": [
@@ -3237,7 +3237,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1226\\",
                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
                     \\"sourcePropertyPath\\": [
@@ -3262,7 +3262,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1227\\",
                     \\"type\\": \\"Properties.DestinationBucketName.Ref -> WebAppBucket8F6FA179\\",
                     \\"sourcePropertyPath\\": [
@@ -3279,7 +3279,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1228\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.Fn::Join.1.3.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                     \\"sourcePropertyPath\\": [
@@ -3304,7 +3304,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1229\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.2.Resource.Fn::Join.1.3.Ref -> InstanceC1063A87\\",
                     \\"sourcePropertyPath\\": [
@@ -3327,7 +3327,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1230\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.3.Resource.Fn::Join.1.3.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
                     \\"sourcePropertyPath\\": [
@@ -3352,7 +3352,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1231\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> WebAppLambdaServiceRoleB3C5DDDA\\",
                     \\"sourcePropertyPath\\": [
@@ -3370,7 +3370,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1232\\",
                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3BucketA30C151C\\",
                     \\"sourcePropertyPath\\": [
@@ -3388,7 +3388,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1233\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
                     \\"sourcePropertyPath\\": [
@@ -3413,7 +3413,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1234\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
                     \\"sourcePropertyPath\\": [
@@ -3438,7 +3438,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1235\\",
                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> WebAppLambdaServiceRoleB3C5DDDA.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3457,7 +3457,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1236\\",
                     \\"type\\": \\"Properties.Environment.Variables.INSTANCE_ID.Ref -> InstanceC1063A87\\",
                     \\"sourcePropertyPath\\": [
@@ -3476,7 +3476,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1237\\",
                     \\"type\\": \\"Properties.Environment.Variables.SECURITY_GROUP_ID.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                     \\"sourcePropertyPath\\": [
@@ -3497,7 +3497,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1238\\",
                     \\"type\\": \\"Properties.Environment.Variables.KEY_PARAMETER_NAME.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
                     \\"sourcePropertyPath\\": [
@@ -3518,7 +3518,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1239\\",
                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
                     \\"sourcePropertyPath\\": [
@@ -3533,7 +3533,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1240\\",
                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleB3C5DDDA\\",
                     \\"sourcePropertyPath\\": [
@@ -3548,7 +3548,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1241\\",
                     \\"type\\": \\"Properties.CloudWatchRoleArn.Fn::GetAtt -> S3GatewayGameAppCloudWatchRole3E18F736.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3567,7 +3567,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1242\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3582,7 +3582,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1243\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3599,7 +3599,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1244\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxyGET2D68D639\\",
                     \\"sourcePropertyPath\\": [
@@ -3614,7 +3614,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1245\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxy2374A00B\\",
                     \\"sourcePropertyPath\\": [
@@ -3629,7 +3629,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1246\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapiANY8309A6C9\\",
                     \\"sourcePropertyPath\\": [
@@ -3644,7 +3644,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1247\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapi997B66C0\\",
                     \\"sourcePropertyPath\\": [
@@ -3659,7 +3659,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1248\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppGET419DC6F4\\",
                     \\"sourcePropertyPath\\": [
@@ -3674,7 +3674,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1249\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3691,7 +3691,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1250\\",
                     \\"type\\": \\"Properties.DeploymentId.Ref -> S3GatewayGameAppDeployment45A40F1C1ea3f370273feac6dc79badcdb1c5090\\",
                     \\"sourcePropertyPath\\": [
@@ -3708,7 +3708,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1251\\",
                     \\"type\\": \\"Properties.ResourceId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                     \\"sourcePropertyPath\\": [
@@ -3727,7 +3727,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1252\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3744,7 +3744,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1253\\",
                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3764,7 +3764,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1254\\",
                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
                     \\"sourcePropertyPath\\": [
@@ -3785,7 +3785,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1255\\",
                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                     \\"sourcePropertyPath\\": [
@@ -3804,7 +3804,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1256\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3821,7 +3821,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1257\\",
                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppproxy2374A00B\\",
                     \\"sourcePropertyPath\\": [
@@ -3838,7 +3838,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1258\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3855,7 +3855,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1259\\",
                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3875,7 +3875,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1260\\",
                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
                     \\"sourcePropertyPath\\": [
@@ -3896,7 +3896,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1261\\",
                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
                     \\"sourcePropertyPath\\": [
@@ -3915,7 +3915,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1262\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3932,7 +3932,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1263\\",
                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3951,7 +3951,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1264\\",
                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -3971,7 +3971,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1265\\",
                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
                     \\"sourcePropertyPath\\": [
@@ -3991,7 +3991,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1266\\",
                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4010,7 +4010,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1267\\",
                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -4030,7 +4030,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1268\\",
                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppapi997B66C0\\",
                     \\"sourcePropertyPath\\": [
@@ -4047,7 +4047,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1269\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -4064,7 +4064,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1270\\",
                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4087,7 +4087,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1271\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4110,7 +4110,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1272\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4136,7 +4136,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1273\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> S3IntegrationRoleF31D2F62\\",
                     \\"sourcePropertyPath\\": [
@@ -4154,7 +4154,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1274\\",
                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
                     \\"sourcePropertyPath\\": [
@@ -4172,7 +4172,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1275\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                     \\"sourcePropertyPath\\": [
@@ -4197,7 +4197,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1276\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
                     \\"sourcePropertyPath\\": [
@@ -4222,7 +4222,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1277\\",
                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> KeyPairProviderCustomResourceProviderRoleA32FD897.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4241,7 +4241,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1278\\",
                     \\"type\\": \\"DependsOn -> KeyPairProviderCustomResourceProviderRoleA32FD897\\",
                     \\"sourcePropertyPath\\": [
@@ -4256,7 +4256,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1279\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                     \\"sourcePropertyPath\\": [
@@ -4280,7 +4280,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1280\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
                     \\"sourcePropertyPath\\": [
@@ -4304,7 +4304,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1281\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4327,7 +4327,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1282\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4353,7 +4353,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1283\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                     \\"sourcePropertyPath\\": [
@@ -4371,7 +4371,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1284\\",
                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
                     \\"sourcePropertyPath\\": [
@@ -4389,7 +4389,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1285\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                     \\"sourcePropertyPath\\": [
@@ -4414,7 +4414,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1286\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
                     \\"sourcePropertyPath\\": [
@@ -4439,7 +4439,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1287\\",
                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -4458,7 +4458,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1288\\",
                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
                     \\"sourcePropertyPath\\": [
@@ -4473,7 +4473,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1289\\",
                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
                     \\"sourcePropertyPath\\": [
@@ -4488,7 +4488,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1290\\",
                     \\"type\\": \\"Value.Fn::Join.1.1.Ref -> S3GatewayGameApp7F73230F\\",
                     \\"sourcePropertyPath\\": [
@@ -4507,7 +4507,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1291\\",
                     \\"type\\": \\"Value.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
                     \\"sourcePropertyPath\\": [
@@ -4526,7 +4526,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1295\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4537,7 +4537,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1299\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4548,7 +4548,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1303\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4559,7 +4559,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1307\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4570,7 +4570,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1311\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4581,7 +4581,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1315\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4592,7 +4592,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1319\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4603,7 +4603,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1323\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4614,7 +4614,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1327\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4625,7 +4625,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1331\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4636,7 +4636,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1335\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4647,7 +4647,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1339\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4658,7 +4658,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1343\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4669,7 +4669,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1347\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4680,7 +4680,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1351\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4691,7 +4691,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1355\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4702,7 +4702,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1359\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4713,7 +4713,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1363\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4724,7 +4724,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1367\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4735,7 +4735,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1371\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4746,7 +4746,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1375\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4757,7 +4757,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1379\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4768,7 +4768,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1383\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4779,7 +4779,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1387\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4790,7 +4790,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1391\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4801,7 +4801,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1395\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4812,7 +4812,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1399\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4823,7 +4823,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1403\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4834,7 +4834,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1407\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4845,7 +4845,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1411\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4856,7 +4856,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1415\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4867,7 +4867,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1419\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4878,7 +4878,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1423\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -4889,7 +4889,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1435\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4900,7 +4900,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1434\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4911,7 +4911,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1436\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4922,7 +4922,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1443\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4933,7 +4933,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1452\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4944,7 +4944,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1470\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4955,7 +4955,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1478\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4966,7 +4966,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1487\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4977,7 +4977,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1502\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4988,7 +4988,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1555\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -4999,7 +4999,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1433\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5010,7 +5010,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1565\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5021,7 +5021,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1574\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5032,7 +5032,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1586\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5043,7 +5043,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1445\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5054,7 +5054,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1444\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5065,7 +5065,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1454\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5076,7 +5076,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1453\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5087,7 +5087,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1458\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5098,7 +5098,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1465\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5109,7 +5109,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1466\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5120,7 +5120,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1459\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5131,7 +5131,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1463\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5142,7 +5142,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1464\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5153,7 +5153,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1471\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5164,7 +5164,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1480\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5175,7 +5175,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1479\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5186,7 +5186,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1489\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5197,7 +5197,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1493\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5208,7 +5208,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1488\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5219,7 +5219,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1495\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5230,7 +5230,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1494\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5241,7 +5241,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1504\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5252,7 +5252,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1508\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5263,7 +5263,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1510\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5274,7 +5274,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1514\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5285,7 +5285,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1519\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5296,7 +5296,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1527\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5307,7 +5307,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1503\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5318,7 +5318,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1509\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5329,7 +5329,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1515\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5340,7 +5340,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1520\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5351,7 +5351,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1529\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5362,7 +5362,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1528\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5373,7 +5373,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1533\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5384,7 +5384,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1543\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5395,7 +5395,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1534\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5406,7 +5406,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1538\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5417,7 +5417,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1539\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5428,7 +5428,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1544\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5439,7 +5439,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1548\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5450,7 +5450,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1549\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5461,7 +5461,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1550\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5472,7 +5472,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1551\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5483,7 +5483,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1556\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5494,7 +5494,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1560\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5505,7 +5505,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1561\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5516,7 +5516,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1566\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5527,7 +5527,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1567\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5538,7 +5538,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1576\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5549,7 +5549,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1580\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5560,7 +5560,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1575\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5571,7 +5571,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1582\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5582,7 +5582,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1581\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5593,7 +5593,7 @@ exports[`CDK kessel run stack template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1587\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -5610,14 +5610,14 @@ exports[`CDK kessel run stack template 1`] = `
 exports[`CDK simple template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"infrastructureState\\",
+        \\"entityType\\": \\"infrastructureState\\",
         \\"_id\\": \\"174\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"components\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"21\\",
                     \\"name\\": \\"Table1725C6B72\\",
                     \\"type\\": \\"Resource\\",
@@ -5654,7 +5654,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"40\\",
                     \\"name\\": \\"ConstructWithTableTable14C141063\\",
                     \\"type\\": \\"Resource\\",
@@ -5691,7 +5691,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"57\\",
                     \\"name\\": \\"Table2DBDCD1F7\\",
                     \\"type\\": \\"Resource\\",
@@ -5725,7 +5725,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"62\\",
                     \\"name\\": \\"user2C2B57AE\\",
                     \\"type\\": \\"Resource\\",
@@ -5742,7 +5742,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"95\\",
                     \\"name\\": \\"userDefaultPolicy083DF682\\",
                     \\"type\\": \\"Resource\\",
@@ -5798,7 +5798,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"103\\",
                     \\"name\\": \\"CDKMetadata\\",
                     \\"type\\": \\"Resource\\",
@@ -5819,7 +5819,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"115\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5834,7 +5834,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"119\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5849,7 +5849,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"123\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5864,7 +5864,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"127\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5879,7 +5879,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"131\\",
                     \\"name\\": \\"Resource\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5894,7 +5894,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"135\\",
                     \\"name\\": \\"Default\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5909,7 +5909,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"139\\",
                     \\"name\\": \\"Table1\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5924,7 +5924,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"142\\",
                     \\"name\\": \\"HelloCdkStack\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5939,7 +5939,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"147\\",
                     \\"name\\": \\"Table1\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5954,7 +5954,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"150\\",
                     \\"name\\": \\"ConstructWithTable\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5969,7 +5969,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"156\\",
                     \\"name\\": \\"Table2\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5984,7 +5984,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"161\\",
                     \\"name\\": \\"user\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -5999,7 +5999,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"166\\",
                     \\"name\\": \\"DefaultPolicy\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -6014,7 +6014,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"171\\",
                     \\"name\\": \\"CDKMetadata\\",
                     \\"type\\": \\"CDK Construct\\"
@@ -6031,7 +6031,7 @@ exports[`CDK simple template 1`] = `
         \\"relationships\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"111\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> Table2DBDCD1F7.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -6054,7 +6054,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"112\\",
                     \\"type\\": \\"Properties.Users.0.Ref -> user2C2B57AE\\",
                     \\"sourcePropertyPath\\": [
@@ -6072,7 +6072,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"116\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -6083,7 +6083,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"120\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -6094,7 +6094,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"124\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -6105,7 +6105,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"128\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -6116,7 +6116,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"132\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -6127,7 +6127,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"136\\",
                     \\"type\\": \\"construct-resource\\"
                 },
@@ -6138,7 +6138,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"144\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6149,7 +6149,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"143\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6160,7 +6160,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"151\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6171,7 +6171,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"157\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6182,7 +6182,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"162\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6193,7 +6193,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"172\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6204,7 +6204,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"153\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6215,7 +6215,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"152\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6226,7 +6226,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"158\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6237,7 +6237,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"163\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6248,7 +6248,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"167\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6259,7 +6259,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"168\\",
                     \\"type\\": \\"construct\\"
                 },
@@ -6270,7 +6270,7 @@ exports[`CDK simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"173\\",
                     \\"type\\": \\"construct\\"
                 },

--- a/packages/change-analysis/test/platform-mapping/cloudformation/__snapshots__/cf-parser.test.ts.snap
+++ b/packages/change-analysis/test/platform-mapping/cloudformation/__snapshots__/cf-parser.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`CloudFormation complex template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"infrastructureState\\",
+        \\"entityType\\": \\"infrastructureState\\",
         \\"_id\\": \\"853\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"components\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"337\\",
                     \\"name\\": \\"root\\",
                     \\"type\\": \\"root\\"
@@ -22,7 +22,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"349\\",
                     \\"name\\": \\"VPCB9E5F0B4\\",
                     \\"type\\": \\"Resource\\",
@@ -50,7 +50,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"368\\",
                     \\"name\\": \\"VPCPublicSubnet1SubnetB4246D30\\",
                     \\"type\\": \\"Resource\\",
@@ -88,7 +88,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"378\\",
                     \\"name\\": \\"VPCPublicSubnet1RouteTableFEE4B781\\",
                     \\"type\\": \\"Resource\\",
@@ -115,7 +115,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"386\\",
                     \\"name\\": \\"VPCPublicSubnet1RouteTableAssociation0B0896DC\\",
                     \\"type\\": \\"Resource\\",
@@ -139,7 +139,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"397\\",
                     \\"name\\": \\"VPCPublicSubnet1DefaultRoute91CEF279\\",
                     \\"type\\": \\"Resource\\",
@@ -167,7 +167,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"406\\",
                     \\"name\\": \\"VPCPublicSubnet1EIP6AD938E8\\",
                     \\"type\\": \\"Resource\\",
@@ -192,7 +192,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"420\\",
                     \\"name\\": \\"VPCPublicSubnet1NATGatewayE0556630\\",
                     \\"type\\": \\"Resource\\",
@@ -225,7 +225,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"439\\",
                     \\"name\\": \\"VPCPublicSubnet2Subnet74179F39\\",
                     \\"type\\": \\"Resource\\",
@@ -263,7 +263,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"449\\",
                     \\"name\\": \\"VPCPublicSubnet2RouteTable6F1A15F1\\",
                     \\"type\\": \\"Resource\\",
@@ -290,7 +290,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"457\\",
                     \\"name\\": \\"VPCPublicSubnet2RouteTableAssociation5A808732\\",
                     \\"type\\": \\"Resource\\",
@@ -314,7 +314,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"468\\",
                     \\"name\\": \\"VPCPublicSubnet2DefaultRouteB7481BBA\\",
                     \\"type\\": \\"Resource\\",
@@ -342,7 +342,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"477\\",
                     \\"name\\": \\"VPCPublicSubnet2EIP4947BC00\\",
                     \\"type\\": \\"Resource\\",
@@ -367,7 +367,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"491\\",
                     \\"name\\": \\"VPCPublicSubnet2NATGateway3C070193\\",
                     \\"type\\": \\"Resource\\",
@@ -400,7 +400,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"510\\",
                     \\"name\\": \\"VPCPublicSubnet3Subnet631C5E25\\",
                     \\"type\\": \\"Resource\\",
@@ -438,7 +438,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"520\\",
                     \\"name\\": \\"VPCPublicSubnet3RouteTable98AE0E14\\",
                     \\"type\\": \\"Resource\\",
@@ -465,7 +465,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"528\\",
                     \\"name\\": \\"VPCPublicSubnet3RouteTableAssociation427FE0C6\\",
                     \\"type\\": \\"Resource\\",
@@ -489,7 +489,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"539\\",
                     \\"name\\": \\"VPCPublicSubnet3DefaultRouteA0D29D46\\",
                     \\"type\\": \\"Resource\\",
@@ -517,7 +517,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"548\\",
                     \\"name\\": \\"VPCPublicSubnet3EIPAD4BC883\\",
                     \\"type\\": \\"Resource\\",
@@ -542,7 +542,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"562\\",
                     \\"name\\": \\"VPCPublicSubnet3NATGatewayD3048F5C\\",
                     \\"type\\": \\"Resource\\",
@@ -575,7 +575,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"581\\",
                     \\"name\\": \\"VPCPrivateSubnet1Subnet8BCA10E0\\",
                     \\"type\\": \\"Resource\\",
@@ -613,7 +613,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"591\\",
                     \\"name\\": \\"VPCPrivateSubnet1RouteTableBE8A6027\\",
                     \\"type\\": \\"Resource\\",
@@ -640,7 +640,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"599\\",
                     \\"name\\": \\"VPCPrivateSubnet1RouteTableAssociation347902D1\\",
                     \\"type\\": \\"Resource\\",
@@ -664,7 +664,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"608\\",
                     \\"name\\": \\"VPCPrivateSubnet1DefaultRouteAE1D6490\\",
                     \\"type\\": \\"Resource\\",
@@ -689,7 +689,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"627\\",
                     \\"name\\": \\"VPCPrivateSubnet2SubnetCFCDAA7A\\",
                     \\"type\\": \\"Resource\\",
@@ -727,7 +727,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"637\\",
                     \\"name\\": \\"VPCPrivateSubnet2RouteTable0A19E10E\\",
                     \\"type\\": \\"Resource\\",
@@ -754,7 +754,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"645\\",
                     \\"name\\": \\"VPCPrivateSubnet2RouteTableAssociation0C73D413\\",
                     \\"type\\": \\"Resource\\",
@@ -778,7 +778,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"654\\",
                     \\"name\\": \\"VPCPrivateSubnet2DefaultRouteF4F5CFD2\\",
                     \\"type\\": \\"Resource\\",
@@ -803,7 +803,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"673\\",
                     \\"name\\": \\"VPCPrivateSubnet3Subnet3EDCD457\\",
                     \\"type\\": \\"Resource\\",
@@ -841,7 +841,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"683\\",
                     \\"name\\": \\"VPCPrivateSubnet3RouteTable192186F8\\",
                     \\"type\\": \\"Resource\\",
@@ -868,7 +868,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"691\\",
                     \\"name\\": \\"VPCPrivateSubnet3RouteTableAssociationC28D144E\\",
                     \\"type\\": \\"Resource\\",
@@ -892,7 +892,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"700\\",
                     \\"name\\": \\"VPCPrivateSubnet3DefaultRoute27F311AE\\",
                     \\"type\\": \\"Resource\\",
@@ -917,7 +917,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"708\\",
                     \\"name\\": \\"VPCIGWB7E252D3\\",
                     \\"type\\": \\"Resource\\",
@@ -941,7 +941,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"716\\",
                     \\"name\\": \\"VPCVPCGW99B986DC\\",
                     \\"type\\": \\"Resource\\",
@@ -965,7 +965,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"739\\",
                     \\"name\\": \\"InstanceInstanceSecurityGroupF0E2D5BE\\",
                     \\"type\\": \\"Resource\\",
@@ -1009,7 +1009,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"761\\",
                     \\"name\\": \\"InstanceInstanceRoleE9785DE5\\",
                     \\"type\\": \\"Resource\\",
@@ -1055,7 +1055,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"776\\",
                     \\"name\\": \\"InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                     \\"type\\": \\"Resource\\",
@@ -1089,7 +1089,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"783\\",
                     \\"name\\": \\"InstanceInstanceProfileAB5AEF02\\",
                     \\"type\\": \\"Resource\\",
@@ -1112,7 +1112,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"809\\",
                     \\"name\\": \\"InstanceC1063A87\\",
                     \\"type\\": \\"Resource\\",
@@ -1162,7 +1162,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"813\\",
                     \\"name\\": \\"SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter\\",
                     \\"type\\": \\"Parameter\\",
@@ -1181,7 +1181,7 @@ exports[`CloudFormation complex template 1`] = `
         \\"relationships\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"814\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1192,7 +1192,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"815\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1203,7 +1203,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"816\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1214,7 +1214,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"817\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1225,7 +1225,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"818\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1236,7 +1236,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"819\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1247,7 +1247,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"820\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1258,7 +1258,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"821\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1269,7 +1269,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"822\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1280,7 +1280,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"823\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1291,7 +1291,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"824\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1302,7 +1302,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"825\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1313,7 +1313,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"826\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1324,7 +1324,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"827\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1335,7 +1335,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"828\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1346,7 +1346,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"829\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1357,7 +1357,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"830\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1368,7 +1368,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"831\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1379,7 +1379,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"832\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1390,7 +1390,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"833\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1401,7 +1401,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"834\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1412,7 +1412,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"835\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1423,7 +1423,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"836\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1434,7 +1434,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"837\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1445,7 +1445,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"838\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1456,7 +1456,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"839\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1467,7 +1467,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"840\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1478,7 +1478,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"841\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1489,7 +1489,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"842\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1500,7 +1500,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"843\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1511,7 +1511,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"844\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1522,7 +1522,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"845\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1533,7 +1533,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"846\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1544,7 +1544,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"847\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1555,7 +1555,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"848\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1566,7 +1566,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"849\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1577,7 +1577,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"850\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1588,7 +1588,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"851\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1599,7 +1599,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"852\\",
                     \\"type\\": \\"root\\"
                 },
@@ -1610,7 +1610,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"854\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -1627,7 +1627,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"855\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -1644,7 +1644,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"856\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet1RouteTableFEE4B781\\",
                     \\"sourcePropertyPath\\": [
@@ -1661,7 +1661,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"857\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet1SubnetB4246D30\\",
                     \\"sourcePropertyPath\\": [
@@ -1678,7 +1678,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"858\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet1RouteTableFEE4B781\\",
                     \\"sourcePropertyPath\\": [
@@ -1695,7 +1695,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"859\\",
                     \\"type\\": \\"Properties.GatewayId.Ref -> VPCIGWB7E252D3\\",
                     \\"sourcePropertyPath\\": [
@@ -1712,7 +1712,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"860\\",
                     \\"type\\": \\"DependsOn -> VPCVPCGW99B986DC\\",
                     \\"sourcePropertyPath\\": [
@@ -1727,7 +1727,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"861\\",
                     \\"type\\": \\"Properties.AllocationId.Fn::GetAtt -> VPCPublicSubnet1EIP6AD938E8.AllocationId\\",
                     \\"sourcePropertyPath\\": [
@@ -1746,7 +1746,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"862\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet1SubnetB4246D30\\",
                     \\"sourcePropertyPath\\": [
@@ -1763,7 +1763,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"863\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -1780,7 +1780,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"864\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -1797,7 +1797,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"865\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet2RouteTable6F1A15F1\\",
                     \\"sourcePropertyPath\\": [
@@ -1814,7 +1814,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"866\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet2Subnet74179F39\\",
                     \\"sourcePropertyPath\\": [
@@ -1831,7 +1831,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"867\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet2RouteTable6F1A15F1\\",
                     \\"sourcePropertyPath\\": [
@@ -1848,7 +1848,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"868\\",
                     \\"type\\": \\"Properties.GatewayId.Ref -> VPCIGWB7E252D3\\",
                     \\"sourcePropertyPath\\": [
@@ -1865,7 +1865,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"869\\",
                     \\"type\\": \\"DependsOn -> VPCVPCGW99B986DC\\",
                     \\"sourcePropertyPath\\": [
@@ -1880,7 +1880,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"870\\",
                     \\"type\\": \\"Properties.AllocationId.Fn::GetAtt -> VPCPublicSubnet2EIP4947BC00.AllocationId\\",
                     \\"sourcePropertyPath\\": [
@@ -1899,7 +1899,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"871\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet2Subnet74179F39\\",
                     \\"sourcePropertyPath\\": [
@@ -1916,7 +1916,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"872\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -1933,7 +1933,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"873\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -1950,7 +1950,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"874\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet3RouteTable98AE0E14\\",
                     \\"sourcePropertyPath\\": [
@@ -1967,7 +1967,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"875\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet3Subnet631C5E25\\",
                     \\"sourcePropertyPath\\": [
@@ -1984,7 +1984,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"876\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet3RouteTable98AE0E14\\",
                     \\"sourcePropertyPath\\": [
@@ -2001,7 +2001,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"877\\",
                     \\"type\\": \\"Properties.GatewayId.Ref -> VPCIGWB7E252D3\\",
                     \\"sourcePropertyPath\\": [
@@ -2018,7 +2018,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"878\\",
                     \\"type\\": \\"DependsOn -> VPCVPCGW99B986DC\\",
                     \\"sourcePropertyPath\\": [
@@ -2033,7 +2033,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"879\\",
                     \\"type\\": \\"Properties.AllocationId.Fn::GetAtt -> VPCPublicSubnet3EIPAD4BC883.AllocationId\\",
                     \\"sourcePropertyPath\\": [
@@ -2052,7 +2052,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"880\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet3Subnet631C5E25\\",
                     \\"sourcePropertyPath\\": [
@@ -2069,7 +2069,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"881\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2086,7 +2086,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"882\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2103,7 +2103,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"883\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet1RouteTableBE8A6027\\",
                     \\"sourcePropertyPath\\": [
@@ -2120,7 +2120,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"884\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet1Subnet8BCA10E0\\",
                     \\"sourcePropertyPath\\": [
@@ -2137,7 +2137,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"885\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet1RouteTableBE8A6027\\",
                     \\"sourcePropertyPath\\": [
@@ -2154,7 +2154,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"886\\",
                     \\"type\\": \\"Properties.NatGatewayId.Ref -> VPCPublicSubnet1NATGatewayE0556630\\",
                     \\"sourcePropertyPath\\": [
@@ -2171,7 +2171,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"887\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2188,7 +2188,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"888\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2205,7 +2205,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"889\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet2RouteTable0A19E10E\\",
                     \\"sourcePropertyPath\\": [
@@ -2222,7 +2222,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"890\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet2SubnetCFCDAA7A\\",
                     \\"sourcePropertyPath\\": [
@@ -2239,7 +2239,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"891\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet2RouteTable0A19E10E\\",
                     \\"sourcePropertyPath\\": [
@@ -2256,7 +2256,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"892\\",
                     \\"type\\": \\"Properties.NatGatewayId.Ref -> VPCPublicSubnet2NATGateway3C070193\\",
                     \\"sourcePropertyPath\\": [
@@ -2273,7 +2273,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"893\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2290,7 +2290,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"894\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2307,7 +2307,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"895\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet3RouteTable192186F8\\",
                     \\"sourcePropertyPath\\": [
@@ -2324,7 +2324,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"896\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet3Subnet3EDCD457\\",
                     \\"sourcePropertyPath\\": [
@@ -2341,7 +2341,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"897\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet3RouteTable192186F8\\",
                     \\"sourcePropertyPath\\": [
@@ -2358,7 +2358,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"898\\",
                     \\"type\\": \\"Properties.NatGatewayId.Ref -> VPCPublicSubnet3NATGatewayD3048F5C\\",
                     \\"sourcePropertyPath\\": [
@@ -2375,7 +2375,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"899\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2392,7 +2392,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"900\\",
                     \\"type\\": \\"Properties.InternetGatewayId.Ref -> VPCIGWB7E252D3\\",
                     \\"sourcePropertyPath\\": [
@@ -2409,7 +2409,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"901\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
                     \\"sourcePropertyPath\\": [
@@ -2426,7 +2426,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"902\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                     \\"sourcePropertyPath\\": [
@@ -2444,7 +2444,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"903\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
                     \\"sourcePropertyPath\\": [
@@ -2462,7 +2462,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"904\\",
                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
                     \\"sourcePropertyPath\\": [
@@ -2479,7 +2479,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"905\\",
                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter\\",
                     \\"sourcePropertyPath\\": [
@@ -2496,7 +2496,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"906\\",
                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
                     \\"sourcePropertyPath\\": [
@@ -2516,7 +2516,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"907\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet1Subnet8BCA10E0\\",
                     \\"sourcePropertyPath\\": [
@@ -2533,7 +2533,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"908\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
                     \\"sourcePropertyPath\\": [
@@ -2548,7 +2548,7 @@ exports[`CloudFormation complex template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"909\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
                     \\"sourcePropertyPath\\": [
@@ -2569,14 +2569,14 @@ exports[`CloudFormation complex template 1`] = `
 exports[`CloudFormation nested template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"infrastructureState\\",
+        \\"entityType\\": \\"infrastructureState\\",
         \\"_id\\": \\"978\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"components\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"911\\",
                     \\"name\\": \\"root\\",
                     \\"type\\": \\"root\\"
@@ -2588,7 +2588,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"926\\",
                     \\"name\\": \\"SomeVPC\\",
                     \\"type\\": \\"Resource\\",
@@ -2621,7 +2621,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"934\\",
                     \\"name\\": \\"NestedStack\\",
                     \\"type\\": \\"Resource\\",
@@ -2645,7 +2645,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"946\\",
                     \\"name\\": \\"SomeVPC\\",
                     \\"type\\": \\"Resource\\",
@@ -2673,7 +2673,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"954\\",
                     \\"name\\": \\"User00B015A1\\",
                     \\"type\\": \\"Resource\\",
@@ -2697,7 +2697,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"958\\",
                     \\"name\\": \\"InnerStackParameter\\",
                     \\"type\\": \\"Parameter\\",
@@ -2714,7 +2714,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"966\\",
                     \\"name\\": \\"InnerOutput\\",
                     \\"type\\": \\"Output\\"
@@ -2738,7 +2738,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"974\\",
                     \\"name\\": \\"OuterStackParameter\\",
                     \\"type\\": \\"Parameter\\",
@@ -2757,7 +2757,7 @@ exports[`CloudFormation nested template 1`] = `
         \\"relationships\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"975\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2768,7 +2768,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"976\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2779,7 +2779,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"977\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2790,7 +2790,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"979\\",
                     \\"type\\": \\"Properties.Tags.0.Value.Fn::GetAtt -> NestedStack.Outputs.InnerOutput\\",
                     \\"sourcePropertyPath\\": [
@@ -2812,7 +2812,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"985\\",
                     \\"type\\": \\"nested-stack-component\\"
                 },
@@ -2823,7 +2823,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"986\\",
                     \\"type\\": \\"nested-stack-component\\"
                 },
@@ -2834,7 +2834,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"987\\",
                     \\"type\\": \\"nested-stack-component\\"
                 },
@@ -2845,7 +2845,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"988\\",
                     \\"type\\": \\"nested-stack-component\\"
                 },
@@ -2856,7 +2856,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"967\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2867,7 +2867,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"968\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2878,7 +2878,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"969\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2889,7 +2889,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"970\\",
                     \\"type\\": \\"root\\"
                 },
@@ -2900,7 +2900,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"981\\",
                     \\"type\\": \\"Properties.SomeProperty.Fn::GetAtt -> InnerStackParameter.Type\\",
                     \\"sourcePropertyPath\\": [
@@ -2919,7 +2919,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"982\\",
                     \\"type\\": \\"nested-parameter\\"
                 },
@@ -2930,7 +2930,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"983\\",
                     \\"type\\": \\"Value.Fn::Sub -> InnerStackParameter\\",
                     \\"sourcePropertyPath\\": [
@@ -2946,7 +2946,7 @@ exports[`CloudFormation nested template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"984\\",
                     \\"type\\": \\"Value.Fn::Sub.1.withAnArgument.Ref -> User00B015A1\\",
                     \\"sourcePropertyPath\\": [
@@ -2971,14 +2971,14 @@ exports[`CloudFormation nested template 1`] = `
 exports[`CloudFormation simple template 1`] = `
 "{
     \\"nodeData\\": {
-        \\"_entityType\\": \\"infrastructureState\\",
+        \\"entityType\\": \\"infrastructureState\\",
         \\"_id\\": \\"331\\"
     },
     \\"outgoingNodeReferences\\": {
         \\"components\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"2\\",
                     \\"name\\": \\"root\\",
                     \\"type\\": \\"root\\"
@@ -2990,7 +2990,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"19\\",
                     \\"name\\": \\"TableCD117FA1\\",
                     \\"type\\": \\"Resource\\",
@@ -3026,7 +3026,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"199\\",
                     \\"name\\": \\"TableWithGlobalAndLocalSecondaryIndexBC540710\\",
                     \\"type\\": \\"Resource\\",
@@ -3289,7 +3289,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"231\\",
                     \\"name\\": \\"TableWithGlobalSecondaryIndexCC8E841E\\",
                     \\"type\\": \\"Resource\\",
@@ -3347,7 +3347,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"269\\",
                     \\"name\\": \\"TableWithLocalSecondaryIndex4DA3D08F\\",
                     \\"type\\": \\"Resource\\",
@@ -3413,7 +3413,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"272\\",
                     \\"name\\": \\"User00B015A1\\",
                     \\"type\\": \\"Resource\\",
@@ -3429,7 +3429,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"component\\",
+                    \\"entityType\\": \\"component\\",
                     \\"_id\\": \\"324\\",
                     \\"name\\": \\"UserDefaultPolicy1F97781E\\",
                     \\"type\\": \\"Resource\\",
@@ -3517,7 +3517,7 @@ exports[`CloudFormation simple template 1`] = `
         \\"relationships\\": [
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"325\\",
                     \\"type\\": \\"root\\"
                 },
@@ -3528,7 +3528,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"326\\",
                     \\"type\\": \\"root\\"
                 },
@@ -3539,7 +3539,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"327\\",
                     \\"type\\": \\"root\\"
                 },
@@ -3550,7 +3550,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"328\\",
                     \\"type\\": \\"root\\"
                 },
@@ -3561,7 +3561,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"329\\",
                     \\"type\\": \\"root\\"
                 },
@@ -3572,7 +3572,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"330\\",
                     \\"type\\": \\"root\\"
                 },
@@ -3583,7 +3583,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"332\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> TableCD117FA1.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3606,7 +3606,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"333\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> TableWithGlobalAndLocalSecondaryIndexBC540710.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3629,7 +3629,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"334\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> TableWithGlobalAndLocalSecondaryIndexBC540710.Arn\\",
                     \\"sourcePropertyPath\\": [
@@ -3655,7 +3655,7 @@ exports[`CloudFormation simple template 1`] = `
             },
             {
                 \\"nodeData\\": {
-                    \\"_entityType\\": \\"relationship\\",
+                    \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"335\\",
                     \\"type\\": \\"Properties.Users.0.Ref -> User00B015A1\\",
                     \\"sourcePropertyPath\\": [

--- a/packages/change-analysis/test/user-configuration/iam-policy-rules.test.ts
+++ b/packages/change-analysis/test/user-configuration/iam-policy-rules.test.ts
@@ -1,4 +1,4 @@
-import { InfraModel } from '../../../change-analysis-models';
+import { InfraModel } from 'cdk-change-analyzer-models';
 import { CFParser } from '../../lib/platform-mapping';
 import { copy } from '../../lib/private/object';
 import { IAM_INLINE_IDENTITY_POLICIES, IAM_INLINE_RESOURCE_POLICIES, IAM_MANAGED_POLICIES, IAM_POLICY_RESOURCES } from '../../lib/private/security-policies';
@@ -30,19 +30,19 @@ describe('IAM Policy default rules', () => {
 
         // WHEN
         const newModel = new CFParser('root', after).parse();
-        const result = processRules(oldModel, newModel, rules);
+        const { graph: g, rulesOutput: result } = processRules(oldModel, newModel, rules);
 
         // THEN
         expect(result.size).toBe(1);
         expect(firstKey(result, appliesTo)).toMatchObject({
           _in: {
-            _entityType: 'component',
+            entityType: 'component',
             type: 'Resource',
             subtype: resource,
           },
           _out: {
             type: 'INSERT',
-            _entityType: 'change',
+            entityType: 'change',
           },
         });
       });
@@ -58,7 +58,7 @@ describe('IAM Policy default rules', () => {
 
         // WHEN
         const newModel = new CFParser('root', after).parse();
-        const result = processRules(_oldModel, newModel, rules);
+        const { graph: g, rulesOutput: result } = processRules(_oldModel, newModel, rules);
 
         // THEN
         expect(result.size).toBe(1);
@@ -84,18 +84,18 @@ describe('IAM Policy default rules', () => {
 
           // WHEN
           const newModel = new CFParser('root', after).parse();
-          const result = processRules(_oldModel, newModel, rules);
+          const { graph: g, rulesOutput: result } = processRules(_oldModel, newModel, rules);
 
           // THEN
           expect(result.size).toBe(1);
           expect(firstKey(result, appliesTo)).toMatchObject({
             _in: {
-              _entityType: 'property',
+              entityType: 'property',
               value: 'abcdefghi',
             },
             _out: {
               propertyOperationType: 'INSERT',
-              _entityType: 'change',
+              entityType: 'change',
             },
           });
         });
@@ -127,18 +127,18 @@ describe('IAM Policy default rules', () => {
 
           // WHEN
           const newModel = new CFParser('root', after).parse();
-          const result = processRules(_oldModel, newModel, rules);
+          const { graph: g, rulesOutput: result } = processRules(_oldModel, newModel, rules);
 
           // THEN
           expect(result.size).toBe(1);
           expect(firstKey(result, appliesTo)).toMatchObject({
             _in: {
-              _entityType: 'property',
+              entityType: 'property',
               value: 'Allow', // A property of the new statement
             },
             _out: {
               propertyOperationType: 'INSERT',
-              _entityType: 'change',
+              entityType: 'change',
             },
           });
         });
@@ -166,18 +166,18 @@ describe('IAM Policy default rules', () => {
 
           // WHEN
           const newModel = new CFParser('root', after).parse();
-          const result = processRules(_oldModel, newModel, rules);
+          const { graph: g, rulesOutput: result } = processRules(_oldModel, newModel, rules);
 
           // THEN
           expect(result.size).toBe(1);
           expect(firstKey(result, appliesTo)).toMatchObject({
             _in: {
-              _entityType: 'property',
+              entityType: 'property',
               value: 'Allow', // A property of the new statement
             },
             _out: {
               propertyOperationType: 'INSERT',
-              _entityType: 'change',
+              entityType: 'change',
             },
           });
         });
@@ -205,18 +205,18 @@ describe('IAM Policy default rules', () => {
 
           // WHEN
           const newModel = new CFParser('root', after).parse();
-          const result = processRules(_oldModel, newModel, rules);
+          const { graph: g, rulesOutput: result } = processRules(_oldModel, newModel, rules);
 
           // THEN
           expect(result.size).toBe(1);
           expect(firstKey(result, appliesTo)).toMatchObject({
             _in: {
-              _entityType: 'property',
+              entityType: 'property',
               value: 'Allow', // A property of the new statement
             },
             _out: {
               propertyOperationType: 'INSERT',
-              _entityType: 'change',
+              entityType: 'change',
             },
           });
         });

--- a/packages/change-analysis/test/user-configuration/rules.test.ts
+++ b/packages/change-analysis/test/user-configuration/rules.test.ts
@@ -29,8 +29,8 @@ const diffTestCase1CRules: CUserRule[] = [{
 
 const diffTestCase1Rules: UserRule[] = [{
   let: {
-    role: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
-    instance: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::EC2::Instance' }},
+    role: { filter: { entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
+    instance: { filter: { entityType: 'component', type: 'resource', subtype: 'AWS::EC2::Instance' }},
   },
   then: [{
     let: {
@@ -38,7 +38,7 @@ const diffTestCase1Rules: UserRule[] = [{
       nested: { propertyReference: {identifier: 'instance', propertyPath: ['nested'] } },
       propComp2_1: { propertyReference: {identifier: 'instance', propertyPath: ['nested', 'propComp2'] } },
       propComp2_2: { propertyReference: {identifier: 'nested', propertyPath: ['propComp2'] } },
-      change: { filter: {_entityType: 'change', type: 'UPDATE' } },
+      change: { filter: {entityType: 'change', type: 'UPDATE' } },
     },
     effect: {
       target: 'change',
@@ -64,9 +64,9 @@ test('Rules conditions parsing', () => {
 
   const expectedRules: UserRules = [{
     let: {
-      role: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
+      role: { filter: { entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
       change: {
-        filter: {_entityType: 'change'},
+        filter: {entityType: 'change'},
         where: [{
           operator: RuleConditionOperator.appliesTo,
           leftInput: {identifier: 'change'},
@@ -86,9 +86,9 @@ test('Rule processor basic filter', () => {
   const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(diffTestCase1Rules);
 
   expect(result.size).toEqual(2);
-  expect([...result][0][0]).toMatchObject({ _entityType: 'change', type: 'UPDATE' });
+  expect([...result][0][0]).toMatchObject({ entityType: 'change', type: 'UPDATE' });
   expect([...result][0][1]).toEqual({risk: RuleRisk.High, action: RuleAction.Reject});
-  expect([...result][1][0]).toMatchObject({ _entityType: 'change', type: 'UPDATE' });
+  expect([...result][1][0]).toMatchObject({ entityType: 'change', type: 'UPDATE' });
   expect([...result][1][1]).toEqual({risk: RuleRisk.High, action: RuleAction.Reject});
 });
 
@@ -98,8 +98,8 @@ test('Rule processor appliesTo condition', () => {
 
   const rules = [{
     let: {
-      role: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
-      change: { filter: {_entityType: 'change' }, where: [{
+      role: { filter: { entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
+      change: { filter: {entityType: 'change' }, where: [{
         leftInput: {identifier: 'change'},
         operator: RuleConditionOperator.appliesTo,
         rightInput: {identifier: 'role'},
@@ -114,6 +114,6 @@ test('Rule processor appliesTo condition', () => {
 
   const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
   expect(result.size).toEqual(1);
-  expect([...result][0][0]).toMatchObject({ _entityType: 'change', type: 'UPDATE' });
+  expect([...result][0][0]).toMatchObject({ entityType: 'change', type: 'UPDATE' });
   expect([...result][0][1]).toEqual({risk: RuleRisk.High, action: RuleAction.Reject});
 });

--- a/packages/change-analysis/test/utils/user-configuration.ts
+++ b/packages/change-analysis/test/utils/user-configuration.ts
@@ -8,7 +8,11 @@ import { CUserRules, RuleProcessor, parseRules, UserRules, RuleOutput } from '..
 export function processRules(oldModel: InfraModel, newModel: InfraModel, rules: CUserRules) {
   const diff = new DiffCreator(new Transition({ v1: oldModel, v2: newModel })).create();
   const _rules: UserRules = parseRules(rules);
-  return new RuleProcessor(diff.generateOutgoingGraph()).processRules(_rules);
+  const graph = diff.generateOutgoingGraph();
+  return {
+    graph,
+    rulesOutput: new RuleProcessor(graph).processRules(_rules)
+  };
 }
 
 export function generateReport(oldModel: InfraModel, newModel: InfraModel, rules: CUserRules) {


### PR DESCRIPTION
`_Xxx` denotes internal data within `fifinet`. Changing to `entityType` to prevent future clashing.

**BREAKING CHANGE**
* `nodeData._entityType` property to `nodeData.entityType`