### PR TITLE
Revert "chore: disable github annotations for linter"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,8 +33,6 @@ jobs:
 
     - name: Lint
       run: yarn lint
-      with:
-        annotations: false
     
     - name: Test
       run: yarn test


### PR DESCRIPTION
Reverts cdklabs/awscdk-change-analyzer#38.. it does nothing