### PR TITLE
feat: add reference and container operator

### DIFF
--- a/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/contains.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/contains.ts
@@ -1,7 +1,6 @@
-import { isScopeVertex, OperatorHandler, ScopeNode } from "../rule-processor";
+import { ModelEntityTypes, RelationshipType } from '@aws-c2a/models';
 import * as fn from 'fifinet';
-import { ModelEntityTypes, RelationshipType } from "@aws-c2a/models";
-import { VertexProps } from "fifinet";
+import { isScopeVertex, OperatorHandler, ScopeNode } from '../rule-processor';
 
 /**
  * Ensures vertex t1 has edge 'source' to intermediary structural relationship vertex with, which has edge 'target' to t2 in graph g
@@ -10,20 +9,23 @@ import { VertexProps } from "fifinet";
  * @param t2 vertex 2
  */
 export const containsHandler: OperatorHandler = <V, E>(
-    g: fn.Graph<V,E>,
-    t1: ScopeNode,
-    t2: ScopeNode
+  g: fn.Graph<V,E>,
+  t1: ScopeNode,
+  t2: ScopeNode,
 ): boolean => {
-    if(!isScopeVertex(t1) || !isScopeVertex(t2)) return false;
+  if(!isScopeVertex(t1) || !isScopeVertex(t2)) return false;
 
-    return g
-        .v(t1.vertex._id)
-        .inAny("source")
-        .filter({_entityType: ModelEntityTypes.relationship, relationshipType: RelationshipType.Structural } as unknown as VertexProps<V>)
-        .outAny("target")
-        .run()
-        .filter(v => v._id === t2.vertex._id)
-        .length > 0;
+  return g
+    .v(t1.vertex._id)
+    .inAny('source')
+    .filter({
+      entityType: ModelEntityTypes.relationship,
+      relationshipType: RelationshipType.Structural,
+    } as unknown as fn.VertexProps<V>)
+    .outAny('target')
+    .run()
+    .filter(v => v._id === t2.vertex._id)
+    .length > 0;
 };
 
 /**
@@ -33,9 +35,9 @@ export const containsHandler: OperatorHandler = <V, E>(
  * @param t2 vertex 2
  */
 export const isContainedInHandler: OperatorHandler = <V, E>(
-    g: fn.Graph<V,E>,
-    t1: ScopeNode,
-    t2: ScopeNode
+  g: fn.Graph<V,E>,
+  t1: ScopeNode,
+  t2: ScopeNode,
 ): boolean => {
-    return containsHandler(g, t2, t1);
+  return containsHandler(g, t2, t1);
 };

--- a/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/contains.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/contains.ts
@@ -1,0 +1,41 @@
+import { isScopeVertex, OperatorHandler, ScopeNode } from "../rule-processor";
+import * as fn from 'fifinet';
+import { ModelEntityTypes, RelationshipType } from "@aws-c2a/models";
+import { VertexProps } from "fifinet";
+
+/**
+ * Ensures vertex t1 has edge 'source' to intermediary structural relationship vertex with, which has edge 'target' to t2 in graph g
+ * @param g the Graph
+ * @param t1 vertex 1
+ * @param t2 vertex 2
+ */
+export const containsHandler: OperatorHandler = <V, E>(
+    g: fn.Graph<V,E>,
+    t1: ScopeNode,
+    t2: ScopeNode
+): boolean => {
+    if(!isScopeVertex(t1) || !isScopeVertex(t2)) return false;
+
+    return g
+        .v(t1.vertex._id)
+        .inAny("source")
+        .filter({_entityType: ModelEntityTypes.relationship, relationshipType: RelationshipType.Structural } as unknown as VertexProps<V>)
+        .outAny("target")
+        .run()
+        .filter(v => v._id === t2.vertex._id)
+        .length > 0;
+};
+
+/**
+ * Ensures vertex t2 has edge 'source' to intermediary structural relationship vertex, which has edge 'target' to t1 in graph g
+ * @param g the Graph
+ * @param t1 vertex 1
+ * @param t2 vertex 2
+ */
+export const isContainedInHandler: OperatorHandler = <V, E>(
+    g: fn.Graph<V,E>,
+    t1: ScopeNode,
+    t2: ScopeNode
+): boolean => {
+    return containsHandler(g, t2, t1);
+};

--- a/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/index.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/index.ts
@@ -1,1 +1,4 @@
 export * from './applies-to';
+export * from './contains';
+export * from './equals';
+export * from './references';

--- a/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/references.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/references.ts
@@ -1,0 +1,41 @@
+import { isScopeVertex, OperatorHandler, ScopeNode } from "../rule-processor";
+import * as fn from 'fifinet';
+import { ModelEntityTypes, RelationshipType } from "@aws-c2a/models";
+import { VertexProps } from "fifinet";
+
+/**
+ * Ensures vertex t1 has edge 'source' to intermediary dependency relationship vertex, which has edge 'target' to t2 in graph g
+ * @param g the Graph
+ * @param t1 vertex 1
+ * @param t2 vertex 2
+ */
+export const referencesHandler: OperatorHandler = <V, E>(
+    g: fn.Graph<V,E>,
+    t1: ScopeNode,
+    t2: ScopeNode
+): boolean => {
+    if(!isScopeVertex(t1) || !isScopeVertex(t2)) return false;
+
+    return g
+        .v(t1.vertex._id)
+        .inAny("source")
+        .filter({_entityType: ModelEntityTypes.relationship, relationshipType: RelationshipType.Dependency } as unknown as VertexProps<V>)
+        .outAny("target")
+        .run()
+        .filter(v => v._id === t2.vertex._id)
+        .length > 0;
+};
+
+/**
+ * Ensures vertex t2 has edge 'source' to intermediary dependency relationship vertex, which has edge 'target' to t1 in graph g
+ * @param g the Graph
+ * @param t1 vertex 1
+ * @param t2 vertex 2
+ */
+export const isReferencedInHandler: OperatorHandler = <V, E>(
+    g: fn.Graph<V,E>,
+    t1: ScopeNode,
+    t2: ScopeNode
+): boolean => {
+    return referencesHandler(g, t2, t1);
+};

--- a/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/references.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/operator-handlers/references.ts
@@ -1,7 +1,7 @@
-import { isScopeVertex, OperatorHandler, ScopeNode } from "../rule-processor";
+import { ModelEntityTypes, RelationshipType } from '@aws-c2a/models';
 import * as fn from 'fifinet';
-import { ModelEntityTypes, RelationshipType } from "@aws-c2a/models";
-import { VertexProps } from "fifinet";
+import { VertexProps } from 'fifinet';
+import { isScopeVertex, OperatorHandler, ScopeNode } from '../rule-processor';
 
 /**
  * Ensures vertex t1 has edge 'source' to intermediary dependency relationship vertex, which has edge 'target' to t2 in graph g
@@ -10,20 +10,23 @@ import { VertexProps } from "fifinet";
  * @param t2 vertex 2
  */
 export const referencesHandler: OperatorHandler = <V, E>(
-    g: fn.Graph<V,E>,
-    t1: ScopeNode,
-    t2: ScopeNode
+  g: fn.Graph<V,E>,
+  t1: ScopeNode,
+  t2: ScopeNode,
 ): boolean => {
-    if(!isScopeVertex(t1) || !isScopeVertex(t2)) return false;
+  if(!isScopeVertex(t1) || !isScopeVertex(t2)) return false;
 
-    return g
-        .v(t1.vertex._id)
-        .inAny("source")
-        .filter({_entityType: ModelEntityTypes.relationship, relationshipType: RelationshipType.Dependency } as unknown as VertexProps<V>)
-        .outAny("target")
-        .run()
-        .filter(v => v._id === t2.vertex._id)
-        .length > 0;
+  return g
+    .v(t1.vertex._id)
+    .inAny('source')
+    .filter({
+      entityType: ModelEntityTypes.relationship,
+      relationshipType: RelationshipType.Dependency,
+    } as unknown as VertexProps<V>)
+    .outAny('target')
+    .run()
+    .filter(v => v._id === t2.vertex._id)
+    .length > 0;
 };
 
 /**
@@ -33,9 +36,9 @@ export const referencesHandler: OperatorHandler = <V, E>(
  * @param t2 vertex 2
  */
 export const isReferencedInHandler: OperatorHandler = <V, E>(
-    g: fn.Graph<V,E>,
-    t1: ScopeNode,
-    t2: ScopeNode
+  g: fn.Graph<V,E>,
+  t1: ScopeNode,
+  t2: ScopeNode,
 ): boolean => {
-    return referencesHandler(g, t2, t1);
+  return referencesHandler(g, t2, t1);
 };

--- a/packages/@aws-c2a/engine/lib/user-configuration/rule-processor.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/rule-processor.ts
@@ -6,19 +6,19 @@ import {
   isContainedInHandler,
   containsHandler,
   isReferencedInHandler,
-  referencesHandler
+  referencesHandler,
 } from './operator-handlers';
 import { equalsHandler } from './operator-handlers/equals';
 import {
-  UserRules, 
+  UserRules,
   UserRule,
   Bindings,
   RuleEffectDefinition,
   Selector,
   selectorIsReference,
   RuleConditions,
-  RuleConditionOperator, 
-  isInputScalar
+  RuleConditionOperator,
+  isInputScalar,
 } from './rule';
 
 /**
@@ -76,7 +76,6 @@ export class RuleProcessor {
 
   private processRule(rule: UserRule, currentScope: RulesScope): RuleOutput{
     const newScopes = rule.let ? this.getScopesFromDeclarations(rule.let, currentScope) : [currentScope];
-
     return new Map([...flatMap(newScopes, (newScope): [ModelEntity, RuleEffect][] => {
       let output = new Map<ModelEntity, RuleEffect>();
       if(rule.effect)

--- a/packages/@aws-c2a/engine/lib/user-configuration/rule-processor.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/rule-processor.ts
@@ -1,9 +1,25 @@
 import { ModelEntity, Serialized, RuleEffect } from '@aws-c2a/models';
 import * as fn from 'fifinet';
 import { flatMap } from '../private/node';
-import { appliesToHandler } from './operator-handlers';
+import {
+  appliesToHandler,
+  isContainedInHandler,
+  containsHandler,
+  isReferencedInHandler,
+  referencesHandler
+} from './operator-handlers';
 import { equalsHandler } from './operator-handlers/equals';
-import { UserRules, UserRule, Bindings, RuleEffectDefinition, Selector, selectorIsReference, RuleConditions, RuleConditionOperator, isInputScalar } from './rule';
+import {
+  UserRules, 
+  UserRule,
+  Bindings,
+  RuleEffectDefinition,
+  Selector,
+  selectorIsReference,
+  RuleConditions,
+  RuleConditionOperator, 
+  isInputScalar
+} from './rule';
 
 /**
  * Process user rules and assign rule effects to the respective vertices in the graph
@@ -33,6 +49,10 @@ export type OperatorHandler = <V, E>(g: fn.Graph<V, E>, t1: ScopeNode, t2: Scope
 const operatorToHandler: Record<RuleConditionOperator, OperatorHandler> = {
   [RuleConditionOperator.appliesTo]: appliesToHandler,
   [RuleConditionOperator.equals]: equalsHandler,
+  [RuleConditionOperator.references]: referencesHandler,
+  [RuleConditionOperator.isReferencedIn]: isReferencedInHandler,
+  [RuleConditionOperator.contains]: containsHandler,
+  [RuleConditionOperator.isContainedIn]: isContainedInHandler,
 };
 
 const propertyPathWildcard = '*';

--- a/packages/@aws-c2a/engine/lib/user-configuration/rule.ts
+++ b/packages/@aws-c2a/engine/lib/user-configuration/rule.ts
@@ -4,10 +4,10 @@ import { RuleEffect } from '@aws-c2a/models';
  * Internal representation of the user defined rules (after parsing)
  */
 export enum RuleConditionOperator {
-  // references = '->', // for following dependency relationships
-  // isReferencedIn = '<-',
-  // contains = '>>', // for following structural relationships
-  // isContainedIn = '<<',
+  references = '->', // for following dependency relationships
+  isReferencedIn = '<-',
+  contains = '>>', // for following structural relationships
+  isContainedIn = '<<',
   appliesTo = 'appliesTo', // for checking a change against an InfraModel entity
   // affects = 'affects', // for checking a change against any directly or indirectly affected InfraModel entity
   equals = '==',

--- a/packages/@aws-c2a/engine/test/default-test-cases/infra-model-diff.ts
+++ b/packages/@aws-c2a/engine/test/default-test-cases/infra-model-diff.ts
@@ -33,7 +33,7 @@ export function diffTestCase1(): InfraModelDiff {
   component1v1.addIncoming(relationship1v1);
   component2v1.addOutgoing(relationship1v1);
   const component3v1 = new Component('component3', 'construct');
-  const relationship2v1 = new StructuralRelationship(component3v1, component1v1, "parent");
+  const relationship2v1 = new StructuralRelationship(component3v1, component1v1, 'parent');
   component1v1.addIncoming(relationship2v1);
   component3v1.addOutgoing(relationship2v1);
 
@@ -60,7 +60,7 @@ export function diffTestCase1(): InfraModelDiff {
   component1v2.addIncoming(relationship1v2);
   component2v2.addOutgoing(relationship1v2);
   const component3v2 = new Component('component3', 'construct');
-  const relationship2v2 = new StructuralRelationship(component3v2, component1v2, "parent");
+  const relationship2v2 = new StructuralRelationship(component3v2, component1v2, 'parent');
   component1v2.addIncoming(relationship2v2);
   component3v2.addOutgoing(relationship2v2);
 

--- a/packages/@aws-c2a/engine/test/default-test-cases/infra-model-diff.ts
+++ b/packages/@aws-c2a/engine/test/default-test-cases/infra-model-diff.ts
@@ -7,6 +7,7 @@ import {
   ComponentPropertyRecord,
   ComponentUpdateType,
   DependencyRelationship,
+  StructuralRelationship,
   InfraModel,
 } from '@aws-c2a/models';
 
@@ -31,7 +32,12 @@ export function diffTestCase1(): InfraModelDiff {
   const relationship1v1 = new DependencyRelationship(component2v1, component1v1, 'relationship1', {sourcePropertyPath: ['nested', 'propComp2']});
   component1v1.addIncoming(relationship1v1);
   component2v1.addOutgoing(relationship1v1);
-  const infraModelv1 = new InfraModel([component1v1, component2v1], [relationship1v1]);
+  const component3v1 = new Component('component3', 'construct');
+  const relationship2v1 = new StructuralRelationship(component3v1, component1v1, "parent");
+  component1v1.addIncoming(relationship2v1);
+  component3v1.addOutgoing(relationship2v1);
+
+  const infraModelv1 = new InfraModel([component1v1, component2v1], [relationship1v1, relationship2v1]);
 
   const component1v2 = new Component('component1', 'resource', {
     subtype: 'AWS::IAM::Role',
@@ -53,7 +59,12 @@ export function diffTestCase1(): InfraModelDiff {
   const relationship1v2 = new DependencyRelationship(component2v2, component1v2, 'relationship1', {sourcePropertyPath: ['nestedNameChanged', 'propComp2NameChanged']});
   component1v2.addIncoming(relationship1v2);
   component2v2.addOutgoing(relationship1v2);
-  const infraModelv2 = new InfraModel([component1v2, component2v2], [relationship1v2]);
+  const component3v2 = new Component('component3', 'construct');
+  const relationship2v2 = new StructuralRelationship(component3v2, component1v2, "parent");
+  component1v2.addIncoming(relationship2v2);
+  component3v2.addOutgoing(relationship2v2);
+
+  const infraModelv2 = new InfraModel([component1v2, component2v2], [relationship1v2, relationship2v2]);
 
   const component1Transition = new Transition<Component>({v1: component1v1, v2: component1v2});
   const component2Transition = new Transition<Component>({v1: component2v1, v2: component2v2});

--- a/packages/@aws-c2a/engine/test/model-diffing/__snapshots__/component-matching.test.ts.snap
+++ b/packages/@aws-c2a/engine/test/model-diffing/__snapshots__/component-matching.test.ts.snap
@@ -1576,6 +1576,7 @@ exports[`Matching basic template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"111\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> Table2DBDCD1F7.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -1599,6 +1600,7 @@ exports[`Matching basic template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"112\\",
                                     \\"type\\": \\"Properties.Users.0.Ref -> user2C2B57AE\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Users\\",
@@ -1616,7 +1618,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"116\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1627,7 +1630,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"120\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1638,7 +1642,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"124\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1649,7 +1654,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"128\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1660,7 +1666,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"132\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1671,7 +1678,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"136\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -1682,7 +1690,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"144\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Table1\\",
@@ -1693,7 +1702,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"143\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1704,7 +1714,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"151\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1715,7 +1726,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"157\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1726,7 +1738,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"162\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1737,7 +1750,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"172\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1748,7 +1762,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"153\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Table1\\",
@@ -1759,7 +1774,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"152\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ConstructWithTable\\",
@@ -1770,7 +1786,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"158\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Table2\\",
@@ -1781,7 +1798,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"163\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]user\\",
@@ -1792,7 +1810,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"167\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]user\\",
@@ -1803,7 +1822,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"168\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -1814,7 +1834,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"173\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CDKMetadata\\",
@@ -1855,6 +1876,7 @@ exports[`Matching basic template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"265\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> Table2DBDCD1F7.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -1878,6 +1900,7 @@ exports[`Matching basic template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"266\\",
                                     \\"type\\": \\"Properties.Users.0.Ref -> user2C2B57AE\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Users\\",
@@ -1895,7 +1918,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"270\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1906,7 +1930,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"274\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1917,7 +1942,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"278\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1928,7 +1954,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"282\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -1939,7 +1966,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"286\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -1950,7 +1978,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"298\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Table1\\",
@@ -1961,7 +1990,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"297\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ConstructWithTable\\",
@@ -1972,7 +2002,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"296\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1983,7 +2014,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"302\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -1994,7 +2026,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"307\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -2005,7 +2038,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"317\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -2016,7 +2050,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"303\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Table2\\",
@@ -2027,7 +2062,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"308\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]user\\",
@@ -2038,7 +2074,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"312\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]user\\",
@@ -2049,7 +2086,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"313\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -2060,7 +2098,8 @@ exports[`Matching basic template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"318\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CDKMetadata\\",
@@ -18912,6 +18951,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2092\\",
                                     \\"type\\": \\"Properties.UserName.Ref -> NVidiaUser1BAF4BFB\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"UserName\\",
@@ -18929,6 +18969,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2093\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> KeyPairProviderCustomResourceProviderHandlerBB6F16AF.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ServiceToken\\",
@@ -18948,6 +18989,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2094\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -18966,6 +19008,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2095\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -18991,6 +19034,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2096\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19016,6 +19060,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2097\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> KeyPairProviderCustomResourceProviderRoleA32FD897.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Role\\",
@@ -19035,6 +19080,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2098\\",
                                     \\"type\\": \\"DependsOn -> KeyPairProviderCustomResourceProviderRoleA32FD897\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19050,6 +19096,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2099\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -19068,6 +19115,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2100\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -19086,6 +19134,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2101\\",
                                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"IamInstanceProfile\\",
@@ -19103,6 +19152,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2102\\",
                                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ImageId\\",
@@ -19120,6 +19170,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2103\\",
                                     \\"type\\": \\"Properties.KeyName.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.KeyName\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"KeyName\\",
@@ -19139,6 +19190,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2104\\",
                                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SecurityGroupIds\\",
@@ -19159,6 +19211,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2105\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.1.Ref -> AccessKey\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Metadata\\",
                                         \\"AWS::CloudFormation::Init\\",
@@ -19184,6 +19237,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2106\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.3.Fn::GetAtt -> AccessKey.SecretAccessKey\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Metadata\\",
                                         \\"AWS::CloudFormation::Init\\",
@@ -19211,6 +19265,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2107\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19226,6 +19281,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2108\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19241,6 +19297,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2109\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ServiceToken\\",
@@ -19260,6 +19317,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2110\\",
                                     \\"type\\": \\"Properties.SourceBucketNames.0.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceBucketNames\\",
@@ -19278,6 +19336,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2111\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3VersionKeyE9526174\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceObjectKeys\\",
@@ -19303,6 +19362,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2112\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3VersionKeyE9526174\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceObjectKeys\\",
@@ -19328,6 +19388,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2113\\",
                                     \\"type\\": \\"Properties.DestinationBucketName.Ref -> WebAppBucket8F6FA179\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"DestinationBucketName\\",
@@ -19345,6 +19406,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2114\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::Join.1.3.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19369,6 +19431,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2115\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.3.Ref -> AssetParameters51b22e860acf2e278d90ceed3a8eecf8c43328a3f5681219f0bcbf8a983df2e3S3Bucket1CF3330C\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19393,6 +19456,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2116\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19416,6 +19480,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2117\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19442,6 +19507,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2118\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -19460,6 +19526,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2119\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19478,6 +19545,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2120\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19503,6 +19571,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2121\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19528,6 +19597,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2122\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Role\\",
@@ -19547,6 +19617,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2123\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19562,6 +19633,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2124\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19577,6 +19649,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2125\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.Fn::Join.1.3.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19602,6 +19675,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2126\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.2.Resource.Fn::Join.1.3.Ref -> InstanceC1063A87\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19625,6 +19699,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2127\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.3.Resource.Fn::Join.1.3.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -19650,6 +19725,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2128\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> WebAppLambdaServiceRoleB3C5DDDA\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -19668,6 +19744,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2129\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3Bucket5BA77413\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19686,6 +19763,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2130\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3VersionKey484CA5B8\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19711,6 +19789,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2131\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersa4185ea71099f2365b20705fccbcddee2495da4691df3f3d55c762b3312807caS3VersionKey484CA5B8\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -19736,6 +19815,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2132\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> WebAppLambdaServiceRoleB3C5DDDA.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Role\\",
@@ -19755,6 +19835,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2133\\",
                                     \\"type\\": \\"Properties.Environment.Variables.INSTANCE_ID.Ref -> InstanceC1063A87\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Environment\\",
@@ -19774,6 +19855,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2134\\",
                                     \\"type\\": \\"Properties.Environment.Variables.SECURITY_GROUP_ID.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Environment\\",
@@ -19795,6 +19877,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2135\\",
                                     \\"type\\": \\"Properties.Environment.Variables.KEY_PARAMETER_NAME.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Environment\\",
@@ -19816,6 +19899,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2136\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19831,6 +19915,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2137\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleB3C5DDDA\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19846,6 +19931,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2138\\",
                                     \\"type\\": \\"Properties.CloudWatchRoleArn.Fn::GetAtt -> S3GatewayGameAppCloudWatchRole3E18F736.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"CloudWatchRoleArn\\",
@@ -19865,6 +19951,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2139\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19880,6 +19967,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2140\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -19897,6 +19985,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2141\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxyGET2D68D639\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19912,6 +20001,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2142\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxy2374A00B\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19927,6 +20017,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2143\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapiANY8309A6C9\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19942,6 +20033,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2144\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapi997B66C0\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19957,6 +20049,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2145\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppGET419DC6F4\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -19972,6 +20065,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2146\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -19989,6 +20083,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2147\\",
                                     \\"type\\": \\"Properties.DeploymentId.Ref -> S3GatewayGameAppDeployment45A40F1C4b3c56c977a48268e4d338b071d20578\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"DeploymentId\\",
@@ -20006,6 +20101,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2148\\",
                                     \\"type\\": \\"Properties.ResourceId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ResourceId\\",
@@ -20025,6 +20121,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2149\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -20042,6 +20139,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2150\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -20062,6 +20160,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2151\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -20083,6 +20182,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2152\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ParentId\\",
@@ -20102,6 +20202,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2153\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -20119,6 +20220,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2154\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppproxy2374A00B\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ResourceId\\",
@@ -20136,6 +20238,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2155\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -20153,6 +20256,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2156\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -20173,6 +20277,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2157\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -20194,6 +20299,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2158\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ParentId\\",
@@ -20213,6 +20319,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2159\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -20230,6 +20337,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2160\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"FunctionName\\",
@@ -20249,6 +20357,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2161\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceArn\\",
@@ -20269,6 +20378,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2162\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceArn\\",
@@ -20289,6 +20399,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2163\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"FunctionName\\",
@@ -20308,6 +20419,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2164\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceArn\\",
@@ -20328,6 +20440,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2165\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppapi997B66C0\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ResourceId\\",
@@ -20345,6 +20458,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2166\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -20362,6 +20476,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2167\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -20385,6 +20500,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2168\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -20408,6 +20524,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2169\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -20434,6 +20551,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2170\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> S3IntegrationRoleF31D2F62\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -20452,6 +20570,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2171\\",
                                     \\"type\\": \\"Value.Fn::Join.1.1.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Value\\",
                                         \\"Fn::Join\\",
@@ -20471,6 +20590,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2172\\",
                                     \\"type\\": \\"Value.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Value\\",
                                         \\"Fn::Join\\",
@@ -20489,7 +20609,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2176\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20500,7 +20621,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2180\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]AccessKey\\",
@@ -20511,7 +20633,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2184\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -20522,7 +20645,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2188\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Role\\",
@@ -20533,7 +20657,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2192\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Handler\\",
@@ -20544,7 +20669,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2196\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20555,7 +20681,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2200\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20566,7 +20693,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2204\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20577,7 +20705,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2208\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceProfile\\",
@@ -20588,7 +20717,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2212\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20599,7 +20729,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2216\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20610,7 +20741,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2220\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -20621,7 +20753,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2224\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20632,7 +20765,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2228\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20643,7 +20777,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2232\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20654,7 +20789,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2236\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20665,7 +20801,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2240\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20676,7 +20813,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2244\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20687,7 +20825,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2248\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20698,7 +20837,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2252\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20709,7 +20849,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2256\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Account\\",
@@ -20720,7 +20861,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2260\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20731,7 +20873,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2264\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20742,7 +20885,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2268\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20753,7 +20897,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2272\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20764,7 +20909,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2276\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20775,7 +20921,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2280\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20786,7 +20933,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2284\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ApiPermission.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
@@ -20797,7 +20945,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2288\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ApiPermission.Test.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
@@ -20808,7 +20957,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2292\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20819,7 +20969,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2296\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20830,7 +20981,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2300\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -20841,7 +20993,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2304\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -20852,7 +21005,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2312\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]NVidiaUser\\",
@@ -20863,7 +21017,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2311\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20874,7 +21029,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2313\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20885,7 +21041,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2320\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20896,7 +21053,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2326\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20907,7 +21065,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2335\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20918,7 +21077,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2353\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20929,7 +21089,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2361\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20940,7 +21101,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2370\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20951,7 +21113,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2385\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20962,7 +21125,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2400\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20973,7 +21137,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2453\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20984,7 +21149,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2463\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -20995,7 +21161,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2322\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KeyPair\\",
@@ -21006,7 +21173,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2321\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameKey\\",
@@ -21017,7 +21185,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2327\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KeyPairProviderCustomResourceProvider\\",
@@ -21028,7 +21197,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2328\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KeyPairProviderCustomResourceProvider\\",
@@ -21039,7 +21209,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2337\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceSecurityGroup\\",
@@ -21050,7 +21221,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2336\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -21061,7 +21233,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2341\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -21072,7 +21245,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2348\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -21083,7 +21257,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2349\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -21094,7 +21269,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2342\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceRole\\",
@@ -21105,7 +21281,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2346\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceRole\\",
@@ -21116,7 +21293,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2347\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -21127,7 +21305,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2354\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppBucket\\",
@@ -21138,7 +21317,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2363\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CustomResource\\",
@@ -21149,7 +21329,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2362\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppDeployment\\",
@@ -21160,7 +21341,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2372\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -21171,7 +21353,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2376\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -21182,7 +21365,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2371\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
@@ -21193,7 +21377,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2378\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
@@ -21204,7 +21389,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2377\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -21215,7 +21401,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2387\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -21226,7 +21413,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2391\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -21237,7 +21425,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2386\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppLambda\\",
@@ -21248,7 +21437,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2393\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppLambda\\",
@@ -21259,7 +21449,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2392\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -21270,7 +21461,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2402\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -21281,7 +21473,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2406\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -21292,7 +21485,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2408\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -21303,7 +21497,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2412\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -21314,7 +21509,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2417\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -21325,7 +21521,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2425\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -21336,7 +21533,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2401\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]S3Gateway\\",
@@ -21347,7 +21545,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2407\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CloudWatchRole\\",
@@ -21358,7 +21557,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2413\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Deployment\\",
@@ -21369,7 +21569,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2418\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DeploymentStage.prod\\",
@@ -21380,7 +21581,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2427\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GET\\",
@@ -21391,7 +21593,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2426\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -21402,7 +21605,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2431\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -21413,7 +21617,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2441\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -21424,7 +21629,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2432\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]{proxy+}\\",
@@ -21435,7 +21641,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2436\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]{proxy+}\\",
@@ -21446,7 +21653,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2437\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GET\\",
@@ -21457,7 +21665,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2442\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]api\\",
@@ -21468,7 +21677,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2446\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]api\\",
@@ -21479,7 +21689,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2447\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -21490,7 +21701,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2448\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -21501,7 +21713,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2449\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -21512,7 +21725,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2454\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]S3IntegrationRole\\",
@@ -21523,7 +21737,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2458\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]S3IntegrationRole\\",
@@ -21534,7 +21749,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2459\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -21545,7 +21761,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"2464\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CDKMetadata\\",
@@ -21682,6 +21899,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3502\\",
                                     \\"type\\": \\"Properties.UserName.Ref -> NVidiaUser1BAF4BFB\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"UserName\\",
@@ -21699,6 +21917,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3503\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> KeyPairProviderCustomResourceProviderHandlerBB6F16AF.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ServiceToken\\",
@@ -21718,6 +21937,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3504\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -21736,6 +21956,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3505\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -21754,6 +21975,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3506\\",
                                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"IamInstanceProfile\\",
@@ -21771,6 +21993,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3507\\",
                                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ImageId\\",
@@ -21788,6 +22011,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3508\\",
                                     \\"type\\": \\"Properties.KeyName.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.KeyName\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"KeyName\\",
@@ -21807,6 +22031,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3509\\",
                                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SecurityGroupIds\\",
@@ -21827,6 +22052,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3510\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.1.Ref -> AccessKey\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Metadata\\",
                                         \\"AWS::CloudFormation::Init\\",
@@ -21852,6 +22078,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3511\\",
                                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.3.Fn::GetAtt -> AccessKey.SecretAccessKey\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Metadata\\",
                                         \\"AWS::CloudFormation::Init\\",
@@ -21879,6 +22106,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3512\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -21894,6 +22122,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3513\\",
                                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -21909,6 +22138,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3514\\",
                                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ServiceToken\\",
@@ -21928,6 +22158,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3515\\",
                                     \\"type\\": \\"Properties.SourceBucketNames.0.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceBucketNames\\",
@@ -21946,6 +22177,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3516\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceObjectKeys\\",
@@ -21971,6 +22203,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3517\\",
                                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceObjectKeys\\",
@@ -21996,6 +22229,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3518\\",
                                     \\"type\\": \\"Properties.DestinationBucketName.Ref -> WebAppBucket8F6FA179\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"DestinationBucketName\\",
@@ -22013,6 +22247,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3519\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.Fn::Join.1.3.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -22038,6 +22273,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3520\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.2.Resource.Fn::Join.1.3.Ref -> InstanceC1063A87\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -22061,6 +22297,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3521\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.3.Resource.Fn::Join.1.3.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -22086,6 +22323,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3522\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> WebAppLambdaServiceRoleB3C5DDDA\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -22104,6 +22342,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3523\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3BucketA30C151C\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -22122,6 +22361,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3524\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -22147,6 +22387,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3525\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -22172,6 +22413,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3526\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> WebAppLambdaServiceRoleB3C5DDDA.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Role\\",
@@ -22191,6 +22433,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3527\\",
                                     \\"type\\": \\"Properties.Environment.Variables.INSTANCE_ID.Ref -> InstanceC1063A87\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Environment\\",
@@ -22210,6 +22453,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3528\\",
                                     \\"type\\": \\"Properties.Environment.Variables.SECURITY_GROUP_ID.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Environment\\",
@@ -22231,6 +22475,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3529\\",
                                     \\"type\\": \\"Properties.Environment.Variables.KEY_PARAMETER_NAME.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Environment\\",
@@ -22252,6 +22497,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3530\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22267,6 +22513,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3531\\",
                                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleB3C5DDDA\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22282,6 +22529,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3532\\",
                                     \\"type\\": \\"Properties.CloudWatchRoleArn.Fn::GetAtt -> S3GatewayGameAppCloudWatchRole3E18F736.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"CloudWatchRoleArn\\",
@@ -22301,6 +22549,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3533\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22316,6 +22565,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3534\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22333,6 +22583,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3535\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxyGET2D68D639\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22348,6 +22599,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3536\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxy2374A00B\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22363,6 +22615,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3537\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapiANY8309A6C9\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22378,6 +22631,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3538\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapi997B66C0\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22393,6 +22647,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3539\\",
                                     \\"type\\": \\"DependsOn -> S3GatewayGameAppGET419DC6F4\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22408,6 +22663,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3540\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22425,6 +22681,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3541\\",
                                     \\"type\\": \\"Properties.DeploymentId.Ref -> S3GatewayGameAppDeployment45A40F1C1ea3f370273feac6dc79badcdb1c5090\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"DeploymentId\\",
@@ -22442,6 +22699,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3542\\",
                                     \\"type\\": \\"Properties.ResourceId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ResourceId\\",
@@ -22461,6 +22719,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3543\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22478,6 +22737,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3544\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -22498,6 +22758,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3545\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -22519,6 +22780,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3546\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ParentId\\",
@@ -22538,6 +22800,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3547\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22555,6 +22818,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3548\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppproxy2374A00B\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ResourceId\\",
@@ -22572,6 +22836,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3549\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22589,6 +22854,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3550\\",
                                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -22609,6 +22875,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3551\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -22630,6 +22897,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3552\\",
                                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ParentId\\",
@@ -22649,6 +22917,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3553\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22666,6 +22935,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3554\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"FunctionName\\",
@@ -22685,6 +22955,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3555\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceArn\\",
@@ -22705,6 +22976,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3556\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceArn\\",
@@ -22725,6 +22997,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3557\\",
                                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"FunctionName\\",
@@ -22744,6 +23017,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3558\\",
                                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"SourceArn\\",
@@ -22764,6 +23038,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3559\\",
                                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppapi997B66C0\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"ResourceId\\",
@@ -22781,6 +23056,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3560\\",
                                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"RestApiId\\",
@@ -22798,6 +23074,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3561\\",
                                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Integration\\",
@@ -22821,6 +23098,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3562\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -22844,6 +23122,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3563\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -22870,6 +23149,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3564\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> S3IntegrationRoleF31D2F62\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -22888,6 +23168,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3565\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -22906,6 +23187,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3566\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -22931,6 +23213,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3567\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -22956,6 +23239,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3568\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> KeyPairProviderCustomResourceProviderRoleA32FD897.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Role\\",
@@ -22975,6 +23259,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3569\\",
                                     \\"type\\": \\"DependsOn -> KeyPairProviderCustomResourceProviderRoleA32FD897\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -22990,6 +23275,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3570\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -23014,6 +23300,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3571\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -23038,6 +23325,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3572\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -23061,6 +23349,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3573\\",
                                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"PolicyDocument\\",
@@ -23087,6 +23376,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3574\\",
                                     \\"type\\": \\"Properties.Roles.0.Ref -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Roles\\",
@@ -23105,6 +23395,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3575\\",
                                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -23123,6 +23414,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3576\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -23148,6 +23440,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3577\\",
                                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Code\\",
@@ -23173,6 +23466,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3578\\",
                                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265.Arn\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Properties\\",
                                         \\"Role\\",
@@ -23192,6 +23486,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3579\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -23207,6 +23502,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3580\\",
                                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"DependsOn\\"
                                     ],
@@ -23222,6 +23518,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3581\\",
                                     \\"type\\": \\"Value.Fn::Join.1.1.Ref -> S3GatewayGameApp7F73230F\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Value\\",
                                         \\"Fn::Join\\",
@@ -23241,6 +23538,7 @@ exports[`Matching big template 1`] = `
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3582\\",
                                     \\"type\\": \\"Value.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
+                                    \\"relationshipType\\": \\"dependency\\",
                                     \\"sourcePropertyPath\\": [
                                         \\"Value\\",
                                         \\"Fn::Join\\",
@@ -23259,7 +23557,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3586\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23270,7 +23569,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3590\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]AccessKey\\",
@@ -23281,7 +23581,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3594\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23292,7 +23593,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3598\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23303,7 +23605,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3602\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23314,7 +23617,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3606\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23325,7 +23629,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3610\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceProfile\\",
@@ -23336,7 +23641,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3614\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23347,7 +23653,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3618\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23358,7 +23665,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3622\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23369,7 +23677,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3626\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23380,7 +23689,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3630\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23391,7 +23701,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3634\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23402,7 +23713,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3638\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23413,7 +23725,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3642\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23424,7 +23737,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3646\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Account\\",
@@ -23435,7 +23749,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3650\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23446,7 +23761,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3654\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23457,7 +23773,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3658\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23468,7 +23785,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3662\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23479,7 +23797,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3666\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23490,7 +23809,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3670\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23501,7 +23821,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3674\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ApiPermission.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
@@ -23512,7 +23833,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3678\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ApiPermission.Test.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
@@ -23523,7 +23845,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3682\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23534,7 +23857,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3686\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23545,7 +23869,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3690\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23556,7 +23881,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3694\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Role\\",
@@ -23567,7 +23893,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3698\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Handler\\",
@@ -23578,7 +23905,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3702\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23589,7 +23917,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3706\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23600,7 +23929,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3710\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -23611,7 +23941,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3714\\",
-                                    \\"type\\": \\"construct-resource\\"
+                                    \\"type\\": \\"construct-resource\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23622,7 +23953,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3726\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]NVidiaUser\\",
@@ -23633,7 +23965,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3725\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23644,7 +23977,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3727\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23655,7 +23989,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3734\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23666,7 +24001,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3743\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23677,7 +24013,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3761\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23688,7 +24025,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3769\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23699,7 +24037,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3778\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23710,7 +24049,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3793\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23721,7 +24061,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3846\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -23732,7 +24073,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3724\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -23743,7 +24085,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3856\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -23754,7 +24097,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3865\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -23765,7 +24109,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3877\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -23776,7 +24121,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3736\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KeyPair\\",
@@ -23787,7 +24133,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3735\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameKey\\",
@@ -23798,7 +24145,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3745\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceSecurityGroup\\",
@@ -23809,7 +24157,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3744\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -23820,7 +24169,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3749\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -23831,7 +24181,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3756\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -23842,7 +24193,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3757\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -23853,7 +24205,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3750\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceRole\\",
@@ -23864,7 +24217,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3754\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]InstanceRole\\",
@@ -23875,7 +24229,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3755\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -23886,7 +24241,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3762\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppBucket\\",
@@ -23897,7 +24253,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3771\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CustomResource\\",
@@ -23908,7 +24265,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3770\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppDeployment\\",
@@ -23919,7 +24277,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3780\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -23930,7 +24289,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3784\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -23941,7 +24301,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3779\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppLambda\\",
@@ -23952,7 +24313,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3786\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]WebAppLambda\\",
@@ -23963,7 +24325,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3785\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -23974,7 +24337,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3795\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -23985,7 +24349,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3799\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -23996,7 +24361,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3801\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -24007,7 +24373,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3805\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -24018,7 +24385,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3810\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -24029,7 +24397,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3818\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -24040,7 +24409,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3794\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]S3Gateway\\",
@@ -24051,7 +24421,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3800\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CloudWatchRole\\",
@@ -24062,7 +24433,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3806\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Deployment\\",
@@ -24073,7 +24445,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3811\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DeploymentStage.prod\\",
@@ -24084,7 +24457,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3820\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GET\\",
@@ -24095,7 +24469,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3819\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -24106,7 +24481,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3824\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -24117,7 +24493,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3834\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Default\\",
@@ -24128,7 +24505,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3825\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]{proxy+}\\",
@@ -24139,7 +24517,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3829\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]{proxy+}\\",
@@ -24150,7 +24529,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3830\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]GET\\",
@@ -24161,7 +24541,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3835\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]api\\",
@@ -24172,7 +24553,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3839\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]api\\",
@@ -24183,7 +24565,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3840\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -24194,7 +24577,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3841\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -24205,7 +24589,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3842\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -24216,7 +24601,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3847\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]S3IntegrationRole\\",
@@ -24227,7 +24613,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3851\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]S3IntegrationRole\\",
@@ -24238,7 +24625,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3852\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -24249,7 +24637,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3857\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KeyPairProviderCustomResourceProvider\\",
@@ -24260,7 +24649,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3858\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]KeyPairProviderCustomResourceProvider\\",
@@ -24271,7 +24661,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3867\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -24282,7 +24673,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3871\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -24293,7 +24685,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3866\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
@@ -24304,7 +24697,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3873\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
@@ -24315,7 +24709,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3872\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -24326,7 +24721,8 @@ exports[`Matching big template 1`] = `
                                 \\"nodeData\\": {
                                     \\"entityType\\": \\"relationship\\",
                                     \\"_id\\": \\"3878\\",
-                                    \\"type\\": \\"construct\\"
+                                    \\"type\\": \\"construct\\",
+                                    \\"relationshipType\\": \\"structural\\"
                                 },
                                 \\"outgoingNodeReferences\\": {
                                     \\"source\\": \\"[dup-ref]CDKMetadata\\",

--- a/packages/@aws-c2a/engine/test/platform-mapping/cdk/__snapshots__/cdk-parser.test.ts.snap
+++ b/packages/@aws-c2a/engine/test/platform-mapping/cdk/__snapshots__/cdk-parser.test.ts.snap
@@ -2951,6 +2951,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1211\\",
                     \\"type\\": \\"Properties.UserName.Ref -> NVidiaUser1BAF4BFB\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"UserName\\",
@@ -2968,6 +2969,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1212\\",
                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> KeyPairProviderCustomResourceProviderHandlerBB6F16AF.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ServiceToken\\",
@@ -2987,6 +2989,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1213\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -3005,6 +3008,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1214\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -3023,6 +3027,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1215\\",
                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"IamInstanceProfile\\",
@@ -3040,6 +3045,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1216\\",
                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullBaseC96584B6F00A464EAD1953AFF4B05118Parameter\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ImageId\\",
@@ -3057,6 +3063,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1217\\",
                     \\"type\\": \\"Properties.KeyName.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.KeyName\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"KeyName\\",
@@ -3076,6 +3083,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1218\\",
                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SecurityGroupIds\\",
@@ -3096,6 +3104,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1219\\",
                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.1.Ref -> AccessKey\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Metadata\\",
                         \\"AWS::CloudFormation::Init\\",
@@ -3121,6 +3130,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1220\\",
                     \\"type\\": \\"Metadata.AWS::CloudFormation::Init.config.commands.000.command.2.Fn::Join.1.3.Fn::GetAtt -> AccessKey.SecretAccessKey\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Metadata\\",
                         \\"AWS::CloudFormation::Init\\",
@@ -3148,6 +3158,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1221\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3163,6 +3174,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1222\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3178,6 +3190,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1223\\",
                     \\"type\\": \\"Properties.ServiceToken.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ServiceToken\\",
@@ -3197,6 +3210,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1224\\",
                     \\"type\\": \\"Properties.SourceBucketNames.0.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SourceBucketNames\\",
@@ -3215,6 +3229,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1225\\",
                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SourceObjectKeys\\",
@@ -3240,6 +3255,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1226\\",
                     \\"type\\": \\"Properties.SourceObjectKeys.0.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3VersionKeyAC52A7BF\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SourceObjectKeys\\",
@@ -3265,6 +3281,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1227\\",
                     \\"type\\": \\"Properties.DestinationBucketName.Ref -> WebAppBucket8F6FA179\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"DestinationBucketName\\",
@@ -3282,6 +3299,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1228\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.Fn::Join.1.3.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -3307,6 +3325,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1229\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.2.Resource.Fn::Join.1.3.Ref -> InstanceC1063A87\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -3330,6 +3349,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1230\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.3.Resource.Fn::Join.1.3.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -3355,6 +3375,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1231\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> WebAppLambdaServiceRoleB3C5DDDA\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -3373,6 +3394,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1232\\",
                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3BucketA30C151C\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -3391,6 +3413,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1233\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -3416,6 +3439,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1234\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters7280837bdc5fccdc07d3a2149d0a19128d434b49fb2f1d2f3618d49fc8ccb8b7S3VersionKeyE2D63F25\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -3441,6 +3465,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1235\\",
                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> WebAppLambdaServiceRoleB3C5DDDA.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Role\\",
@@ -3460,6 +3485,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1236\\",
                     \\"type\\": \\"Properties.Environment.Variables.INSTANCE_ID.Ref -> InstanceC1063A87\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Environment\\",
@@ -3479,6 +3505,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1237\\",
                     \\"type\\": \\"Properties.Environment.Variables.SECURITY_GROUP_ID.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Environment\\",
@@ -3500,6 +3527,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1238\\",
                     \\"type\\": \\"Properties.Environment.Variables.KEY_PARAMETER_NAME.Fn::GetAtt -> GameKeyKeyPairF8B1B0F0.Parameter\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Environment\\",
@@ -3521,6 +3549,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1239\\",
                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleDefaultPolicyB264392B\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3536,6 +3565,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1240\\",
                     \\"type\\": \\"DependsOn -> WebAppLambdaServiceRoleB3C5DDDA\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3551,6 +3581,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1241\\",
                     \\"type\\": \\"Properties.CloudWatchRoleArn.Fn::GetAtt -> S3GatewayGameAppCloudWatchRole3E18F736.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"CloudWatchRoleArn\\",
@@ -3570,6 +3601,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1242\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3585,6 +3617,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1243\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -3602,6 +3635,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1244\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxyGET2D68D639\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3617,6 +3651,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1245\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppproxy2374A00B\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3632,6 +3667,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1246\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapiANY8309A6C9\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3647,6 +3683,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1247\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppapi997B66C0\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3662,6 +3699,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1248\\",
                     \\"type\\": \\"DependsOn -> S3GatewayGameAppGET419DC6F4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -3677,6 +3715,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1249\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -3694,6 +3733,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1250\\",
                     \\"type\\": \\"Properties.DeploymentId.Ref -> S3GatewayGameAppDeployment45A40F1C1ea3f370273feac6dc79badcdb1c5090\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"DeploymentId\\",
@@ -3711,6 +3751,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1251\\",
                     \\"type\\": \\"Properties.ResourceId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ResourceId\\",
@@ -3730,6 +3771,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1252\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -3747,6 +3789,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1253\\",
                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Integration\\",
@@ -3767,6 +3810,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1254\\",
                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Integration\\",
@@ -3788,6 +3832,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1255\\",
                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ParentId\\",
@@ -3807,6 +3852,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1256\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -3824,6 +3870,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1257\\",
                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppproxy2374A00B\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ResourceId\\",
@@ -3841,6 +3888,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1258\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -3858,6 +3906,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1259\\",
                     \\"type\\": \\"Properties.Integration.Credentials.Fn::GetAtt -> S3IntegrationRoleF31D2F62.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Integration\\",
@@ -3878,6 +3927,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1260\\",
                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Ref -> WebAppBucket8F6FA179\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Integration\\",
@@ -3899,6 +3949,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1261\\",
                     \\"type\\": \\"Properties.ParentId.Fn::GetAtt -> S3GatewayGameApp7F73230F.RootResourceId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ParentId\\",
@@ -3918,6 +3969,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1262\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -3935,6 +3987,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1263\\",
                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"FunctionName\\",
@@ -3954,6 +4007,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1264\\",
                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SourceArn\\",
@@ -3974,6 +4028,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1265\\",
                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SourceArn\\",
@@ -3994,6 +4049,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1266\\",
                     \\"type\\": \\"Properties.FunctionName.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"FunctionName\\",
@@ -4013,6 +4069,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1267\\",
                     \\"type\\": \\"Properties.SourceArn.Fn::Join.1.3.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SourceArn\\",
@@ -4033,6 +4090,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1268\\",
                     \\"type\\": \\"Properties.ResourceId.Ref -> S3GatewayGameAppapi997B66C0\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ResourceId\\",
@@ -4050,6 +4108,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1269\\",
                     \\"type\\": \\"Properties.RestApiId.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RestApiId\\",
@@ -4067,6 +4126,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1270\\",
                     \\"type\\": \\"Properties.Integration.Uri.Fn::Join.1.3.Fn::GetAtt -> WebAppLambdaE4C4A83F.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Integration\\",
@@ -4090,6 +4150,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1271\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -4113,6 +4174,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1272\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -4139,6 +4201,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1273\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> S3IntegrationRoleF31D2F62\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -4157,6 +4220,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1274\\",
                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3Bucket69CDE7B7\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -4175,6 +4239,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1275\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -4200,6 +4265,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1276\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParameters0ea6850d4748eaa29d5c7ef4a6311b0f76f9b676df76117567fdd928264ed047S3VersionKey3E23C446\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -4225,6 +4291,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1277\\",
                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> KeyPairProviderCustomResourceProviderRoleA32FD897.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Role\\",
@@ -4244,6 +4311,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1278\\",
                     \\"type\\": \\"DependsOn -> KeyPairProviderCustomResourceProviderRoleA32FD897\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -4259,6 +4327,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1279\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -4283,6 +4352,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1280\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.1.Fn::Join.1.3.Ref -> AssetParameters522e3faafd5b22898326f128416f06eda8c003192b4bba70e122fb98addd381fS3Bucket8F15CD9D\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -4307,6 +4377,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1281\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -4330,6 +4401,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1282\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> WebAppBucket8F6FA179.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -4356,6 +4428,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1283\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -4374,6 +4447,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1284\\",
                     \\"type\\": \\"Properties.Code.S3Bucket.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3Bucket77147E20\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -4392,6 +4466,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1285\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.0.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -4417,6 +4492,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1286\\",
                     \\"type\\": \\"Properties.Code.S3Key.Fn::Join.1.1.Fn::Select.1.Fn::Split.1.Ref -> AssetParametersc9ac4b3b65f3510a2088b7fd003de23d2aefac424025eb168725ce6769e3c176S3VersionKey4253216F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Code\\",
@@ -4442,6 +4518,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1287\\",
                     \\"type\\": \\"Properties.Role.Fn::GetAtt -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Role\\",
@@ -4461,6 +4538,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1288\\",
                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -4476,6 +4554,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1289\\",
                     \\"type\\": \\"DependsOn -> CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -4491,6 +4570,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1290\\",
                     \\"type\\": \\"Value.Fn::Join.1.1.Ref -> S3GatewayGameApp7F73230F\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Value\\",
                         \\"Fn::Join\\",
@@ -4510,6 +4590,7 @@ exports[`CDK kessel run stack template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1291\\",
                     \\"type\\": \\"Value.Fn::Join.1.5.Ref -> S3GatewayGameAppDeploymentStageprod501ACE37\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Value\\",
                         \\"Fn::Join\\",
@@ -4528,7 +4609,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1295\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4539,7 +4621,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1299\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]AccessKey\\",
@@ -4550,7 +4633,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1303\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4561,7 +4645,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1307\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4572,7 +4657,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1311\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4583,7 +4669,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1315\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4594,7 +4681,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1319\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]InstanceProfile\\",
@@ -4605,7 +4693,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1323\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4616,7 +4705,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1327\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4627,7 +4717,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1331\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4638,7 +4729,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1335\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4649,7 +4741,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1339\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4660,7 +4753,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1343\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4671,7 +4765,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1347\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4682,7 +4777,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1351\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4693,7 +4789,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1355\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Account\\",
@@ -4704,7 +4801,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1359\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4715,7 +4813,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1363\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4726,7 +4825,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1367\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4737,7 +4837,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1371\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4748,7 +4849,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1375\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4759,7 +4861,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1379\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4770,7 +4873,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1383\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ApiPermission.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
@@ -4781,7 +4885,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1387\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ApiPermission.Test.KesselRunStackS3GatewayGameAppDDC26D96.ANY..api\\",
@@ -4792,7 +4897,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1391\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4803,7 +4909,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1395\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4814,7 +4921,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1399\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4825,7 +4933,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1403\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Role\\",
@@ -4836,7 +4945,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1407\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Handler\\",
@@ -4847,7 +4957,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1411\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4858,7 +4969,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1415\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4869,7 +4981,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1419\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -4880,7 +4993,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1423\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4891,7 +5005,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1435\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NVidiaUser\\",
@@ -4902,7 +5017,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1434\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4913,7 +5029,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1436\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4924,7 +5041,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1443\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4935,7 +5053,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1452\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4946,7 +5065,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1470\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4957,7 +5077,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1478\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4968,7 +5089,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1487\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4979,7 +5101,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1502\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -4990,7 +5113,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1555\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -5001,7 +5125,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1433\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -5012,7 +5137,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1565\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -5023,7 +5149,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1574\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -5034,7 +5161,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1586\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KesselRunStack\\",
@@ -5045,7 +5173,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1445\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KeyPair\\",
@@ -5056,7 +5185,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1444\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameKey\\",
@@ -5067,7 +5197,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1454\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]InstanceSecurityGroup\\",
@@ -5078,7 +5209,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1453\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -5089,7 +5221,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1458\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -5100,7 +5233,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1465\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -5111,7 +5245,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1466\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Instance\\",
@@ -5122,7 +5257,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1459\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]InstanceRole\\",
@@ -5133,7 +5269,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1463\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]InstanceRole\\",
@@ -5144,7 +5281,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1464\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -5155,7 +5293,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1471\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]WebAppBucket\\",
@@ -5166,7 +5305,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1480\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]CustomResource\\",
@@ -5177,7 +5317,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1479\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]WebAppDeployment\\",
@@ -5188,7 +5329,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1489\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -5199,7 +5341,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1493\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -5210,7 +5353,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1488\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]WebAppLambda\\",
@@ -5221,7 +5365,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1495\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]WebAppLambda\\",
@@ -5232,7 +5377,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1494\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -5243,7 +5389,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1504\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -5254,7 +5401,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1508\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -5265,7 +5413,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1510\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -5276,7 +5425,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1514\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -5287,7 +5437,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1519\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -5298,7 +5449,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1527\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GameApp\\",
@@ -5309,7 +5461,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1503\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]S3Gateway\\",
@@ -5320,7 +5473,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1509\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]CloudWatchRole\\",
@@ -5331,7 +5485,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1515\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Deployment\\",
@@ -5342,7 +5497,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1520\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]DeploymentStage.prod\\",
@@ -5353,7 +5509,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1529\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GET\\",
@@ -5364,7 +5521,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1528\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -5375,7 +5533,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1533\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -5386,7 +5545,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1543\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -5397,7 +5557,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1534\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]{proxy+}\\",
@@ -5408,7 +5569,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1538\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]{proxy+}\\",
@@ -5419,7 +5581,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1539\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]GET\\",
@@ -5430,7 +5593,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1544\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]api\\",
@@ -5441,7 +5605,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1548\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]api\\",
@@ -5452,7 +5617,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1549\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -5463,7 +5629,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1550\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -5474,7 +5641,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1551\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ANY\\",
@@ -5485,7 +5653,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1556\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]S3IntegrationRole\\",
@@ -5496,7 +5665,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1560\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]S3IntegrationRole\\",
@@ -5507,7 +5677,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1561\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -5518,7 +5689,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1566\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KeyPairProviderCustomResourceProvider\\",
@@ -5529,7 +5701,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1567\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]KeyPairProviderCustomResourceProvider\\",
@@ -5540,7 +5713,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1576\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -5551,7 +5725,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1580\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ServiceRole\\",
@@ -5562,7 +5737,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1575\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
@@ -5573,7 +5749,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1582\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C\\",
@@ -5584,7 +5761,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1581\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -5595,7 +5773,8 @@ exports[`CDK kessel run stack template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"1587\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]CDKMetadata\\",
@@ -6034,6 +6213,7 @@ exports[`CDK simple template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"111\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> Table2DBDCD1F7.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -6057,6 +6237,7 @@ exports[`CDK simple template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"112\\",
                     \\"type\\": \\"Properties.Users.0.Ref -> user2C2B57AE\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Users\\",
@@ -6074,7 +6255,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"116\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -6085,7 +6267,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"120\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -6096,7 +6279,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"124\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -6107,7 +6291,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"128\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -6118,7 +6303,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"132\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Resource\\",
@@ -6129,7 +6315,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"136\\",
-                    \\"type\\": \\"construct-resource\\"
+                    \\"type\\": \\"construct-resource\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Default\\",
@@ -6140,7 +6327,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"144\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Table1\\",
@@ -6151,7 +6339,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"143\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -6162,7 +6351,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"151\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -6173,7 +6363,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"157\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -6184,7 +6375,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"162\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -6195,7 +6387,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"172\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]HelloCdkStack\\",
@@ -6206,7 +6399,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"153\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Table1\\",
@@ -6217,7 +6411,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"152\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]ConstructWithTable\\",
@@ -6228,7 +6423,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"158\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]Table2\\",
@@ -6239,7 +6435,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"163\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]user\\",
@@ -6250,7 +6447,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"167\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]user\\",
@@ -6261,7 +6459,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"168\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]DefaultPolicy\\",
@@ -6272,7 +6471,8 @@ exports[`CDK simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"173\\",
-                    \\"type\\": \\"construct\\"
+                    \\"type\\": \\"construct\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]CDKMetadata\\",

--- a/packages/@aws-c2a/engine/test/platform-mapping/cloudformation/__snapshots__/cf-parser.test.ts.snap
+++ b/packages/@aws-c2a/engine/test/platform-mapping/cloudformation/__snapshots__/cf-parser.test.ts.snap
@@ -1183,7 +1183,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"814\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1194,7 +1195,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"815\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1205,7 +1207,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"816\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1216,7 +1219,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"817\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1227,7 +1231,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"818\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1238,7 +1243,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"819\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1249,7 +1255,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"820\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1260,7 +1267,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"821\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1271,7 +1279,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"822\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1282,7 +1291,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"823\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1293,7 +1303,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"824\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1304,7 +1315,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"825\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1315,7 +1327,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"826\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1326,7 +1339,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"827\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1337,7 +1351,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"828\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1348,7 +1363,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"829\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1359,7 +1375,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"830\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1370,7 +1387,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"831\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1381,7 +1399,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"832\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1392,7 +1411,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"833\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1403,7 +1423,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"834\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1414,7 +1435,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"835\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1425,7 +1447,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"836\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1436,7 +1459,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"837\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1447,7 +1471,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"838\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1458,7 +1483,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"839\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1469,7 +1495,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"840\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1480,7 +1507,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"841\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1491,7 +1519,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"842\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1502,7 +1531,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"843\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1513,7 +1543,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"844\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1524,7 +1555,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"845\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1535,7 +1567,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"846\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1546,7 +1579,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"847\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1557,7 +1591,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"848\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1568,7 +1603,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"849\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1579,7 +1615,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"850\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1590,7 +1627,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"851\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1601,7 +1639,8 @@ exports[`CloudFormation complex template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"852\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -1613,6 +1652,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"854\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -1630,6 +1670,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"855\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -1647,6 +1688,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"856\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet1RouteTableFEE4B781\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -1664,6 +1706,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"857\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet1SubnetB4246D30\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -1681,6 +1724,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"858\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet1RouteTableFEE4B781\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -1698,6 +1742,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"859\\",
                     \\"type\\": \\"Properties.GatewayId.Ref -> VPCIGWB7E252D3\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"GatewayId\\",
@@ -1715,6 +1760,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"860\\",
                     \\"type\\": \\"DependsOn -> VPCVPCGW99B986DC\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -1730,6 +1776,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"861\\",
                     \\"type\\": \\"Properties.AllocationId.Fn::GetAtt -> VPCPublicSubnet1EIP6AD938E8.AllocationId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"AllocationId\\",
@@ -1749,6 +1796,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"862\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet1SubnetB4246D30\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -1766,6 +1814,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"863\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -1783,6 +1832,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"864\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -1800,6 +1850,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"865\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet2RouteTable6F1A15F1\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -1817,6 +1868,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"866\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet2Subnet74179F39\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -1834,6 +1886,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"867\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet2RouteTable6F1A15F1\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -1851,6 +1904,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"868\\",
                     \\"type\\": \\"Properties.GatewayId.Ref -> VPCIGWB7E252D3\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"GatewayId\\",
@@ -1868,6 +1922,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"869\\",
                     \\"type\\": \\"DependsOn -> VPCVPCGW99B986DC\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -1883,6 +1938,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"870\\",
                     \\"type\\": \\"Properties.AllocationId.Fn::GetAtt -> VPCPublicSubnet2EIP4947BC00.AllocationId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"AllocationId\\",
@@ -1902,6 +1958,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"871\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet2Subnet74179F39\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -1919,6 +1976,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"872\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -1936,6 +1994,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"873\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -1953,6 +2012,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"874\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet3RouteTable98AE0E14\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -1970,6 +2030,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"875\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet3Subnet631C5E25\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -1987,6 +2048,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"876\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPublicSubnet3RouteTable98AE0E14\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2004,6 +2066,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"877\\",
                     \\"type\\": \\"Properties.GatewayId.Ref -> VPCIGWB7E252D3\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"GatewayId\\",
@@ -2021,6 +2084,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"878\\",
                     \\"type\\": \\"DependsOn -> VPCVPCGW99B986DC\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -2036,6 +2100,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"879\\",
                     \\"type\\": \\"Properties.AllocationId.Fn::GetAtt -> VPCPublicSubnet3EIPAD4BC883.AllocationId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"AllocationId\\",
@@ -2055,6 +2120,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"880\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPublicSubnet3Subnet631C5E25\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -2072,6 +2138,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"881\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2089,6 +2156,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"882\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2106,6 +2174,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"883\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet1RouteTableBE8A6027\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2123,6 +2192,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"884\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet1Subnet8BCA10E0\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -2140,6 +2210,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"885\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet1RouteTableBE8A6027\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2157,6 +2228,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"886\\",
                     \\"type\\": \\"Properties.NatGatewayId.Ref -> VPCPublicSubnet1NATGatewayE0556630\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"NatGatewayId\\",
@@ -2174,6 +2246,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"887\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2191,6 +2264,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"888\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2208,6 +2282,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"889\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet2RouteTable0A19E10E\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2225,6 +2300,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"890\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet2SubnetCFCDAA7A\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -2242,6 +2318,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"891\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet2RouteTable0A19E10E\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2259,6 +2336,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"892\\",
                     \\"type\\": \\"Properties.NatGatewayId.Ref -> VPCPublicSubnet2NATGateway3C070193\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"NatGatewayId\\",
@@ -2276,6 +2354,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"893\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2293,6 +2372,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"894\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2310,6 +2390,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"895\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet3RouteTable192186F8\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2327,6 +2408,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"896\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet3Subnet3EDCD457\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -2344,6 +2426,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"897\\",
                     \\"type\\": \\"Properties.RouteTableId.Ref -> VPCPrivateSubnet3RouteTable192186F8\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"RouteTableId\\",
@@ -2361,6 +2444,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"898\\",
                     \\"type\\": \\"Properties.NatGatewayId.Ref -> VPCPublicSubnet3NATGatewayD3048F5C\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"NatGatewayId\\",
@@ -2378,6 +2462,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"899\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2395,6 +2480,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"900\\",
                     \\"type\\": \\"Properties.InternetGatewayId.Ref -> VPCIGWB7E252D3\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"InternetGatewayId\\",
@@ -2412,6 +2498,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"901\\",
                     \\"type\\": \\"Properties.VpcId.Ref -> VPCB9E5F0B4\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"VpcId\\",
@@ -2429,6 +2516,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"902\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -2447,6 +2535,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"903\\",
                     \\"type\\": \\"Properties.Roles.0.Ref -> InstanceInstanceRoleE9785DE5\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Roles\\",
@@ -2465,6 +2554,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"904\\",
                     \\"type\\": \\"Properties.IamInstanceProfile.Ref -> InstanceInstanceProfileAB5AEF02\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"IamInstanceProfile\\",
@@ -2482,6 +2572,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"905\\",
                     \\"type\\": \\"Properties.ImageId.Ref -> SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"ImageId\\",
@@ -2499,6 +2590,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"906\\",
                     \\"type\\": \\"Properties.SecurityGroupIds.0.Fn::GetAtt -> InstanceInstanceSecurityGroupF0E2D5BE.GroupId\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SecurityGroupIds\\",
@@ -2519,6 +2611,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"907\\",
                     \\"type\\": \\"Properties.SubnetId.Ref -> VPCPrivateSubnet1Subnet8BCA10E0\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SubnetId\\",
@@ -2536,6 +2629,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"908\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleDefaultPolicy4ACE9290\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -2551,6 +2645,7 @@ exports[`CloudFormation complex template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"909\\",
                     \\"type\\": \\"DependsOn -> InstanceInstanceRoleE9785DE5\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"DependsOn\\"
                     ],
@@ -2759,7 +2854,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"975\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -2770,7 +2866,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"976\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -2781,7 +2878,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"977\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -2793,6 +2891,7 @@ exports[`CloudFormation nested template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"979\\",
                     \\"type\\": \\"Properties.Tags.0.Value.Fn::GetAtt -> NestedStack.Outputs.InnerOutput\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Tags\\",
@@ -2814,7 +2913,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"985\\",
-                    \\"type\\": \\"nested-stack-component\\"
+                    \\"type\\": \\"nested-stack-component\\",
+                    \\"relationshipType\\": \\"dependency\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2825,7 +2925,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"986\\",
-                    \\"type\\": \\"nested-stack-component\\"
+                    \\"type\\": \\"nested-stack-component\\",
+                    \\"relationshipType\\": \\"dependency\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2836,7 +2937,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"987\\",
-                    \\"type\\": \\"nested-stack-component\\"
+                    \\"type\\": \\"nested-stack-component\\",
+                    \\"relationshipType\\": \\"dependency\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2847,7 +2949,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"988\\",
-                    \\"type\\": \\"nested-stack-component\\"
+                    \\"type\\": \\"nested-stack-component\\",
+                    \\"relationshipType\\": \\"dependency\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2858,7 +2961,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"967\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2869,7 +2973,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"968\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2880,7 +2985,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"969\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2891,7 +2997,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"970\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]NestedStack\\",
@@ -2903,6 +3010,7 @@ exports[`CloudFormation nested template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"981\\",
                     \\"type\\": \\"Properties.SomeProperty.Fn::GetAtt -> InnerStackParameter.Type\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"SomeProperty\\",
@@ -2921,7 +3029,8 @@ exports[`CloudFormation nested template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"982\\",
-                    \\"type\\": \\"nested-parameter\\"
+                    \\"type\\": \\"nested-parameter\\",
+                    \\"relationshipType\\": \\"dependency\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]InnerStackParameter\\",
@@ -2933,6 +3042,7 @@ exports[`CloudFormation nested template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"983\\",
                     \\"type\\": \\"Value.Fn::Sub -> InnerStackParameter\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Value\\",
                         \\"Fn::Sub\\"
@@ -2949,6 +3059,7 @@ exports[`CloudFormation nested template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"984\\",
                     \\"type\\": \\"Value.Fn::Sub.1.withAnArgument.Ref -> User00B015A1\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Value\\",
                         \\"Fn::Sub\\",
@@ -3519,7 +3630,8 @@ exports[`CloudFormation simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"325\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -3530,7 +3642,8 @@ exports[`CloudFormation simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"326\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -3541,7 +3654,8 @@ exports[`CloudFormation simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"327\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -3552,7 +3666,8 @@ exports[`CloudFormation simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"328\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -3563,7 +3678,8 @@ exports[`CloudFormation simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"329\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -3574,7 +3690,8 @@ exports[`CloudFormation simple template 1`] = `
                 \\"nodeData\\": {
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"330\\",
-                    \\"type\\": \\"root\\"
+                    \\"type\\": \\"root\\",
+                    \\"relationshipType\\": \\"structural\\"
                 },
                 \\"outgoingNodeReferences\\": {
                     \\"source\\": \\"[dup-ref]root\\",
@@ -3586,6 +3703,7 @@ exports[`CloudFormation simple template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"332\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.0.Resource.0.Fn::GetAtt -> TableCD117FA1.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -3609,6 +3727,7 @@ exports[`CloudFormation simple template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"333\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.0.Fn::GetAtt -> TableWithGlobalAndLocalSecondaryIndexBC540710.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -3632,6 +3751,7 @@ exports[`CloudFormation simple template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"334\\",
                     \\"type\\": \\"Properties.PolicyDocument.Statement.1.Resource.1.Fn::Join.1.0.Fn::GetAtt -> TableWithGlobalAndLocalSecondaryIndexBC540710.Arn\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"PolicyDocument\\",
@@ -3658,6 +3778,7 @@ exports[`CloudFormation simple template 1`] = `
                     \\"entityType\\": \\"relationship\\",
                     \\"_id\\": \\"335\\",
                     \\"type\\": \\"Properties.Users.0.Ref -> User00B015A1\\",
+                    \\"relationshipType\\": \\"dependency\\",
                     \\"sourcePropertyPath\\": [
                         \\"Properties\\",
                         \\"Users\\",

--- a/packages/@aws-c2a/engine/test/user-configuration/rules-relationship-operator.test.ts
+++ b/packages/@aws-c2a/engine/test/user-configuration/rules-relationship-operator.test.ts
@@ -1,0 +1,125 @@
+import { diffTestCase1 } from "../default-test-cases/infra-model-diff";
+import { RuleConditions, RuleProcessor, UserRules } from "../../user-configuration";
+import { RuleAction, RuleRisk } from "change-analysis-models";
+import { RuleConditionOperator } from "../../user-configuration";
+
+/**
+ * Generates rules for example diff 1 with the specified conditions
+ * @param t1 
+ * @param operator 
+ * @param t2 
+ * @returns 
+ */
+function generateRulesWithConditions(conditions: RuleConditions): UserRules{
+    return [{
+        let: {
+            role: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
+            instance: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::EC2::Instance' } },
+            construct: { filter: { _entityType: 'component', type: 'construct' } },
+            change: { filter: {_entityType: 'change' }, where: conditions }
+        },
+        effect: {
+            target: 'change',
+            risk: RuleRisk.High,
+            action: RuleAction.Reject
+        }
+    }];
+}
+
+test('Rule processor condition with references operator', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'instance'},
+        operator: RuleConditionOperator.references,
+        rightInput: {identifier: 'role'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(2);
+});
+
+test('Rule processor condition with references operator in opposite direction should fail', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'role'},
+        operator: RuleConditionOperator.references,
+        rightInput: {identifier: 'instance'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(0);
+});
+
+test('Rule processor condition with isReferencedIn operator', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'role'},
+        operator: RuleConditionOperator.isReferencedIn,
+        rightInput: {identifier: 'instance'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(2);
+});
+
+test('Rule processor condition with contains operator', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'construct'},
+        operator: RuleConditionOperator.contains,
+        rightInput: {identifier: 'role'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(2);
+});
+
+test('Rule processor condition with contains operator finds nothing', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'construct'},
+        operator: RuleConditionOperator.contains,
+        rightInput: {identifier: 'instance'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(0);
+});
+
+test('Rule processor condition with isContainedIn operator', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'role'},
+        operator: RuleConditionOperator.isContainedIn,
+        rightInput: {identifier: 'construct'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(2);
+});
+
+test('Rule processor condition with contains operator should not match reference relationships', () => {
+
+    const diff = diffTestCase1();
+
+    const rules = generateRulesWithConditions([{
+        leftInput: {identifier: 'instance'},
+        operator: RuleConditionOperator.contains,
+        rightInput: {identifier: 'role'}
+    }]); 
+
+    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+    expect(result.size).toEqual(0);
+});

--- a/packages/@aws-c2a/engine/test/user-configuration/rules-relationship-operator.test.ts
+++ b/packages/@aws-c2a/engine/test/user-configuration/rules-relationship-operator.test.ts
@@ -1,125 +1,124 @@
-import { diffTestCase1 } from "../default-test-cases/infra-model-diff";
-import { RuleConditions, RuleProcessor, UserRules } from "../../user-configuration";
-import { RuleAction, RuleRisk } from "change-analysis-models";
-import { RuleConditionOperator } from "../../user-configuration";
+import { RuleAction, RuleRisk } from '@aws-c2a/models';
+import { RuleConditions, RuleConditionOperator, RuleProcessor, UserRules } from '../../lib';
+import { diffTestCase1 } from '../default-test-cases/infra-model-diff';
 
 /**
  * Generates rules for example diff 1 with the specified conditions
- * @param t1 
- * @param operator 
- * @param t2 
- * @returns 
+ * @param t1
+ * @param operator
+ * @param t2
+ * @returns
  */
 function generateRulesWithConditions(conditions: RuleConditions): UserRules{
-    return [{
-        let: {
-            role: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
-            instance: { filter: { _entityType: 'component', type: 'resource', subtype: 'AWS::EC2::Instance' } },
-            construct: { filter: { _entityType: 'component', type: 'construct' } },
-            change: { filter: {_entityType: 'change' }, where: conditions }
-        },
-        effect: {
-            target: 'change',
-            risk: RuleRisk.High,
-            action: RuleAction.Reject
-        }
-    }];
+  return [{
+    let: {
+      role: { filter: { entityType: 'component', type: 'resource', subtype: 'AWS::IAM::Role' }},
+      instance: { filter: { entityType: 'component', type: 'resource', subtype: 'AWS::EC2::Instance' } },
+      construct: { filter: { entityType: 'component', type: 'construct' } },
+      change: { filter: {entityType: 'change' }, where: conditions },
+    },
+    effect: {
+      target: 'change',
+      risk: RuleRisk.High,
+      action: RuleAction.Reject,
+    },
+  }];
 }
 
 test('Rule processor condition with references operator', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'instance'},
-        operator: RuleConditionOperator.references,
-        rightInput: {identifier: 'role'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'instance'},
+    operator: RuleConditionOperator.references,
+    rightInput: {identifier: 'role'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(2);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(2);
 });
 
 test('Rule processor condition with references operator in opposite direction should fail', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'role'},
-        operator: RuleConditionOperator.references,
-        rightInput: {identifier: 'instance'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'role'},
+    operator: RuleConditionOperator.references,
+    rightInput: {identifier: 'instance'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(0);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(0);
 });
 
 test('Rule processor condition with isReferencedIn operator', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'role'},
-        operator: RuleConditionOperator.isReferencedIn,
-        rightInput: {identifier: 'instance'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'role'},
+    operator: RuleConditionOperator.isReferencedIn,
+    rightInput: {identifier: 'instance'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(2);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(2);
 });
 
 test('Rule processor condition with contains operator', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'construct'},
-        operator: RuleConditionOperator.contains,
-        rightInput: {identifier: 'role'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'construct'},
+    operator: RuleConditionOperator.contains,
+    rightInput: {identifier: 'role'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(2);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(2);
 });
 
 test('Rule processor condition with contains operator finds nothing', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'construct'},
-        operator: RuleConditionOperator.contains,
-        rightInput: {identifier: 'instance'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'construct'},
+    operator: RuleConditionOperator.contains,
+    rightInput: {identifier: 'instance'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(0);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(0);
 });
 
 test('Rule processor condition with isContainedIn operator', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'role'},
-        operator: RuleConditionOperator.isContainedIn,
-        rightInput: {identifier: 'construct'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'role'},
+    operator: RuleConditionOperator.isContainedIn,
+    rightInput: {identifier: 'construct'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(2);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(2);
 });
 
 test('Rule processor condition with contains operator should not match reference relationships', () => {
 
-    const diff = diffTestCase1();
+  const diff = diffTestCase1();
 
-    const rules = generateRulesWithConditions([{
-        leftInput: {identifier: 'instance'},
-        operator: RuleConditionOperator.contains,
-        rightInput: {identifier: 'role'}
-    }]); 
+  const rules = generateRulesWithConditions([{
+    leftInput: {identifier: 'instance'},
+    operator: RuleConditionOperator.contains,
+    rightInput: {identifier: 'role'},
+  }]);
 
-    const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
-    expect(result.size).toEqual(0);
+  const result = new RuleProcessor(diff.generateOutgoingGraph()).processRules(rules);
+  expect(result.size).toEqual(0);
 });

--- a/packages/@aws-c2a/models/infra-model/dependency-relationship.ts
+++ b/packages/@aws-c2a/models/infra-model/dependency-relationship.ts
@@ -4,7 +4,7 @@ import { SerializationClasses } from '../export/serialization-classes';
 import { SerializedDependencyRelationship } from '../export/serialized-interfaces/infra-model/serialized-relationship';
 import { Component } from './component';
 import { PropertyPath } from './component-property';
-import { Relationship, RelationshipData } from './relationship';
+import { Relationship, RelationshipData, RelationshipType } from './relationship';
 
 export type DependencyRelationshipOptions = {
   readonly sourcePropertyPath?: PropertyPath
@@ -23,7 +23,7 @@ export class DependencyRelationship extends Relationship<DependencyRelationshipD
   public get targetAttributePath(): PropertyPath { return this.nodeData.targetAttributePath ?? []; }
 
   constructor(source: Component, target: Component, type: string, options?: DependencyRelationshipOptions){
-    super(source, target, {type, ...options});
+    super(source, target, {type, relationshipType: RelationshipType.Dependency, ...options});
   }
 
   public toSerialized(serialize: (obj: JSONSerializable) => SerializationID): SerializedDependencyRelationship {

--- a/packages/@aws-c2a/models/infra-model/relationship.ts
+++ b/packages/@aws-c2a/models/infra-model/relationship.ts
@@ -5,8 +5,14 @@ import { Component } from './component';
 import { ModelEntity } from './model-entity';
 import { ModelEntityTypes } from './model-entity-types';
 
+export enum RelationshipType {
+  Dependency = 'dependency',
+  Structural = 'structural'
+}
+
 export type RelationshipData = {
   readonly type: string;
+  readonly relationshipType: RelationshipType;
 }
 
 export type RelationshipEdges = {

--- a/packages/@aws-c2a/models/infra-model/structural-relationship.ts
+++ b/packages/@aws-c2a/models/infra-model/structural-relationship.ts
@@ -1,6 +1,6 @@
 import { SerializationClasses } from '../export/serialization-classes';
 import { Component } from './component';
-import { Relationship } from './relationship';
+import { Relationship, RelationshipType } from './relationship';
 
 /**
  * StructuralRelationship establishes a conceptual hierarchy between
@@ -10,7 +10,7 @@ import { Relationship } from './relationship';
 export class StructuralRelationship extends Relationship {
 
   constructor(source: Component, target: Component, type: string){
-    super(source, target, {type});
+    super(source, target, {type, relationshipType: RelationshipType.Structural});
   }
 
   public getSerializationClass(): string{


### PR DESCRIPTION
- Implement `references`, `isReferencedIn`, `contains` and `isContainedIn` operators
- Relationships now contain a `relationshipType` field to have that information in their graph vertices. Updated testing snapshots to keep up with this change
- Expand diffTestCase1 to include a structural relationship
- Introduce the appropriate tests