### PR TITLE
feat: integrate @aws-c2a/visualizer into cli

### DIFF
--- a/packages/@aws-c2a/visualizer/src/App.tsx
+++ b/packages/@aws-c2a/visualizer/src/App.tsx
@@ -13,7 +13,9 @@ interface HomeProps {
   after: string;
 }
 
-const createGraph = (before: any, after: any): fn.Graph<any, any> => {
+const createGraph = (p_before: any, p_after: any): fn.Graph<any, any> => {
+  const before = typeof p_before === 'string' ? JSON.parse(p_before) : p_before;
+  const after = typeof p_after === 'string' ? JSON.parse(p_after) : p_after;
   const oldModel = new c2a.CDKParser('root', before).parse();
   const newModel = new c2a.CDKParser('root', after).parse();
 
@@ -44,9 +46,12 @@ export default function App({before, after}: HomeProps): JSX.Element {
         },
       ],
     });
-    cy.current.on('select', 'node', (event) => {
+    const eventCb = (event) => {
       setSelected(JSON.stringify(event.target.map(node => node._private.data), null, 2));
-    });
+    };
+    cy.current.on('mouseover', 'node', eventCb);
+    cy.current.on('select', 'node', eventCb);
+    cy.current.on('select', 'edge', eventCb);
     return () => {
       if (cy.current && !cy.current.destroyed()) {
         cy.current.destroy();
@@ -55,7 +60,7 @@ export default function App({before, after}: HomeProps): JSX.Element {
   }, []);
 
   useEffect(() => {
-    const _graph = createGraph(JSON.parse(before), JSON.parse(after));
+    const _graph = createGraph(before, after);
     setGraph(_graph);
   }, [before, after]);
 
@@ -78,6 +83,7 @@ export default function App({before, after}: HomeProps): JSX.Element {
         cy.current.add({
           group: 'edges',
           data: {
+            label: e._label,
             id: e._id,
             source: e._out._id,
             target: e._in._id,

--- a/packages/aws-c2a/README.md
+++ b/packages/aws-c2a/README.md
@@ -11,7 +11,7 @@ Computes the difference between the current cloud assembly state and the current
 outputs the report to a file and returns 0 if no differences are found.
 
 ```sh
-aws-c2a diff --app='path/to/assembly/' --rules-path='path/to/rules.json' --output='path/to/output.json'
+aws-c2a diff --app='path/to/assembly/' --rules-path='path/to/rules.json' --out='path/to/output.json'
 ```
 
 ### `aws-c2a html`
@@ -19,5 +19,16 @@ aws-c2a diff --app='path/to/assembly/' --rules-path='path/to/rules.json' --outpu
 Generate an html file that aggregates the output of `aws-c2a diff`.
 
 ```sh
-aws-c2a html --report='path/to/change-report.json' --output='path/to/index.html'
+aws-c2a html --report='path/to/change-report.json' --out='path/to/index.html'
+```
+
+### `aws-c2a vis`
+
+Generate an html file that visualizes the diff tree of your app.
+
+> Currently, only evaluates the first object in the template tree and **does not** 
+support nested stacks
+
+```sh
+aws-c2a vis --app='path/to/assembly/' --out='path/to/index.html'
 ```

--- a/packages/aws-c2a/lib/cfn-traverser.ts
+++ b/packages/aws-c2a/lib/cfn-traverser.ts
@@ -3,7 +3,7 @@ import { IC2AHost } from './c2a-host';
 import { CloudAssembly } from './cloud-assembly';
 import { resolveCfnProperty } from './private/cfn';
 import { deserializeStructure } from './private/yml';
-import { TemplateTree } from './toolkit';
+import { TemplateTree } from './toolkit-utils';
 
 interface StackInfo {
   template: any;

--- a/packages/aws-c2a/lib/index.ts
+++ b/packages/aws-c2a/lib/index.ts
@@ -1,4 +1,5 @@
-export * from './toolkit';
 export * from './c2a-host';
 export * from './cfn-traverser';
 export * from './cloud-assembly';
+export * from './toolkit';
+export * from './toolkit-utils';

--- a/packages/aws-c2a/lib/private/fs.ts
+++ b/packages/aws-c2a/lib/private/fs.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs';
+
+export async function getFileIfExists(path: string, fileName: string): Promise<string> {
+  try {
+    const file = await fs.promises.readFile(path, 'utf-8');
+    return file;
+  } catch {
+    throw new Error(`${fileName} not found or unable to read at path, ${path}.`);
+  }
+}

--- a/packages/aws-c2a/lib/private/toolkit-utils.ts
+++ b/packages/aws-c2a/lib/private/toolkit-utils.ts
@@ -1,0 +1,22 @@
+import { CDKParser } from '@aws-c2a/engine';
+import { InfraModel } from '@aws-c2a/models';
+import { flattenObjects, mapObjectValues } from './object';
+
+export type TemplateTreeMap = {[id: string]: TemplateTree}
+
+export interface TemplateTree {
+  readonly rootTemplate: any;
+  readonly nestedTemplates?: TemplateTreeMap;
+}
+
+export const flattenNestedStacks = (nestedStacks: {[id: string]: TemplateTree} | undefined ): {[id: string]: any}  => {
+  return Object.entries(nestedStacks ?? {})
+    .reduce((acc, [stackName, {rootTemplate, nestedTemplates}]: [string, TemplateTree]) =>
+      ({...acc, [stackName]: rootTemplate, ...(flattenNestedStacks(nestedTemplates))}), {});
+};
+
+export const createModel = (trees: TemplateTreeMap): InfraModel => {
+  return new CDKParser('root', ...mapObjectValues(trees, tree => tree.rootTemplate)).parse({
+    nestedStacks: flattenObjects(mapObjectValues(trees, app => flattenNestedStacks(app.nestedTemplates))),
+  });
+};

--- a/packages/aws-c2a/lib/toolkit-utils.ts
+++ b/packages/aws-c2a/lib/toolkit-utils.ts
@@ -1,6 +1,6 @@
 import { CDKParser } from '@aws-c2a/engine';
 import { InfraModel } from '@aws-c2a/models';
-import { flattenObjects, mapObjectValues } from './object';
+import { flattenObjects, mapObjectValues } from './private/object';
 
 export type TemplateTreeMap = {[id: string]: TemplateTree}
 

--- a/packages/aws-c2a/lib/toolkit.ts
+++ b/packages/aws-c2a/lib/toolkit.ts
@@ -8,7 +8,7 @@ import { CfnTraverser } from './cfn-traverser';
 import { CloudAssembly, DefaultSelection, StackCollection } from './cloud-assembly';
 import { getFileIfExists } from './private/fs';
 import { warning, error } from './private/logging';
-import { createModel, TemplateTree, TemplateTreeMap } from './private/toolkit-utils';
+import { createModel, TemplateTree, TemplateTreeMap } from './toolkit-utils';
 const webappTemplatePath = require.resolve('@aws-c2a/web-app/fixtures/template.index.html');
 const visTemplatePath = require.resolve('@aws-c2a/visualizer/fixtures/template.index.html');
 


### PR DESCRIPTION
Generate an html file that visualizes the diff tree of your app.

> Currently, only evaluates the first object in the template tree and **does not** 
support nested stacks

```sh
aws-c2a vis --app='path/to/assembly/' --out='path/to/index.html'
```